### PR TITLE
Use sms inbox

### DIFF
--- a/sms_inbox.py
+++ b/sms_inbox.py
@@ -13,7 +13,7 @@ def get_nessage():
     if result:
         cache.clear()
         return jsonify({
-            'result': 'sucess',
+            'result': 'success',
             'sms_code': result
         }), 200
     else:
@@ -25,7 +25,6 @@ def get_nessage():
 
 @app.route('/', methods=['POST'])
 def receive_message():
-    print(request.values)
     cache.set('sms', request.form['Body'], timeout=300)
     return jsonify({
         'result': 'success'
@@ -34,8 +33,6 @@ def receive_message():
 
 @app.route('/test-integration', methods=['POST'])
 def test_integration():
-    print(request.get_data())
-    print(request.headers)
     return jsonify({
         'result': 'success'
     }), 200

--- a/sms_inbox.py
+++ b/sms_inbox.py
@@ -39,5 +39,5 @@ def test_integration():
 
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 6001))	
+    port = int(os.environ.get('PORT', 6001))
     app.run(host='0.0.0.0', port=port)

--- a/tests/test_csv_upload_flow.py
+++ b/tests/test_csv_upload_flow.py
@@ -1,66 +1,47 @@
-import uuid
-import datetime
-import sys
-import re
-import time
-import imaplib
-import email as email_lib
-import email.header
-import pytest
 from requests import session
+
 from config import Config
-from tests.utils import (retrieve_sms_with_wait,
-                         delete_sms_message,
-                         find_csrf_token,
-                         get_sms,
+from tests.utils import (find_csrf_token,
+                         get_sms_via_heroku,
                          create_sample_csv_file,
                          sign_in,
-                         sign_out,
-                         delete_default_sms)
+                         sign_out)
 
 
 def test_csv_upload_journey():
-    delete_default_sms()
     client = session()
     base_url = Config.NOTIFY_ADMIN_URL
-    try:
-        sign_in(
-            client,
-            base_url,
-            Config.FUNCTIONAL_TEST_EMAIL,
-            Config.FUNCTIONAL_TEST_PASSWORD)
-        csv_upload_url = '{}/services/{}/send/{}'.format(
-            base_url,
-            Config.FUNCTIONAL_SERVICE_ID,
-            Config.FUNCTIONAL_TEMPLATE_ID)
-        get_csv_upload = client.get(csv_upload_url)
-        next_token = find_csrf_token(get_csv_upload.text)
-        csv_file = create_sample_csv_file([[Config.TWILIO_TEST_NUMBER]])
-        files = {'file': ("preview_file.csv", csv_file, 'text/csv')}
-        data = {'csrf_token': next_token}
-        msgs = []
-        post_csv_upload = client.post(
-            csv_upload_url,
-            data=data,
-            files=files,
-            headers=dict(Referer=csv_upload_url))
-        assert post_csv_upload.status_code == 200
-        assert 'services/{}/check'.format(Config.FUNCTIONAL_SERVICE_ID) in post_csv_upload.url
-        next_token = find_csrf_token(post_csv_upload.text)
-        data = data = {'csrf_token': next_token}
-        post_check_sms = client.post(
-            post_csv_upload.url,
-            data=data,
-            headers=dict(Referer=post_csv_upload.url))
-        assert post_check_sms.status_code == 200
-        assert '/jobs' in post_check_sms.url
-        msgs = retrieve_sms_with_wait(Config.FUNCTIONAL_TEST_EMAIL)
-    finally:
-        # Make sure to delete all msgs from the account
-        delete_default_sms()
-    # Test will fail if there is not 1 message (we expect only 1 message)
-    assert len(msgs) == 1, 'Expecting to retrieve 1 sms message in functional test for user: {}'.format(
-        Config.FUNCTIONAL_TEST_EMAIL)
+    sign_in(
+        client,
+        base_url,
+        Config.FUNCTIONAL_TEST_EMAIL,
+        Config.FUNCTIONAL_TEST_PASSWORD)
+    csv_upload_url = '{}/services/{}/send/{}'.format(
+        base_url,
+        Config.FUNCTIONAL_SERVICE_ID,
+        Config.FUNCTIONAL_TEMPLATE_ID)
+    get_csv_upload = client.get(csv_upload_url)
+    next_token = find_csrf_token(get_csv_upload.text)
+    csv_file = create_sample_csv_file([[Config.TWILIO_TEST_NUMBER]])
+    files = {'file': ("preview_file.csv", csv_file, 'text/csv')}
+    data = {'csrf_token': next_token}
+    post_csv_upload = client.post(
+        csv_upload_url,
+        data=data,
+        files=files,
+        headers=dict(Referer=csv_upload_url))
+    assert post_csv_upload.status_code == 200
+    assert 'services/{}/check'.format(Config.FUNCTIONAL_SERVICE_ID) in post_csv_upload.url
+    next_token = find_csrf_token(post_csv_upload.text)
+    data = {'csrf_token': next_token}
+    post_check_sms = client.post(
+        post_csv_upload.url,
+        data=data,
+        headers=dict(Referer=post_csv_upload.url))
+    assert post_check_sms.status_code == 200
+    assert '/jobs' in post_check_sms.url
+    message = get_sms_via_heroku(client)
+
     # Verify the correct sms message was sent
-    assert "The quick brown fox jumped over the lazy dog" in msgs[0].body
+    assert "The quick brown fox jumped over the lazy dog" in message
     sign_out(client, base_url)

--- a/tests/test_register_flow.py
+++ b/tests/test_register_flow.py
@@ -78,7 +78,7 @@ def test_register_journey():
     # Redirects followed
     try:
         post_register_resp = client.post(base_url + '/register', data=data,
-                                         headers=dict(Referer=base_url+'/register'))
+                                         headers=dict(Referer=base_url + '/register'))
         assert post_register_resp.status_code == 200
 
         next_token = find_csrf_token(post_register_resp.text)
@@ -95,7 +95,7 @@ def test_register_journey():
                        'email_code': email_code,
                        'csrf_token': next_token}
     post_verify = client.post(base_url + '/verify', data=two_factor_data,
-                              headers=dict(Referer=base_url+'/verify'))
+                              headers=dict(Referer=base_url + '/verify'))
     assert post_verify.status_code == 200
     assert 'Which service do you want to set up notifications for?' in post_verify.text
     sign_out(client, base_url)

--- a/tests/test_signin_flow.py
+++ b/tests/test_signin_flow.py
@@ -1,62 +1,51 @@
 from requests import session
 
 from config import Config
-from tests.utils import (retrieve_sms_with_wait,
-                         delete_sms_message,
-                         find_csrf_token,
-                         get_sms,
+from tests.utils import (find_csrf_token,
+                         get_sms_via_heroku,
                          sign_out,
-                         find_page_title,
-                         delete_default_sms
+                         find_page_title
                          )
 
 
 def test_sign_in_journey():
-    delete_default_sms()
-    try:
-        client = session()
-        base_url = Config.NOTIFY_ADMIN_URL
-        index_resp = client.get(base_url)
-        assert index_resp.status_code == 200
-        assert 'GOV.UK Notify' == find_page_title(index_resp.text)
+    client = session()
+    base_url = Config.NOTIFY_ADMIN_URL
+    index_resp = client.get(base_url)
+    assert index_resp.status_code == 200
+    assert 'GOV.UK Notify' == find_page_title(index_resp.text)
 
-        get_sign_resp = client.get(base_url + '/sign-in')
-        assert 200 == get_sign_resp.status_code
-        assert 'Sign in - GOV.UK Notify'
+    get_sign_resp = client.get(base_url + '/sign-in')
+    assert 200 == get_sign_resp.status_code
+    assert 'Sign in - GOV.UK Notify'
 
-        token = find_csrf_token(get_sign_resp.text)
+    token = find_csrf_token(get_sign_resp.text)
 
-        user_name = Config.FUNCTIONAL_TEST_EMAIL
-        password = Config.FUNCTIONAL_TEST_PASSWORD
-        assert user_name is not None
-        data = {'email_address': user_name,
-                'password': password,
-                'csrf_token': token}
-        post_sign_in_resp = client.post(base_url + '/sign-in', data=data,
-                                        headers=dict(Referer=base_url+'/sign-in'))
-        assert post_sign_in_resp.status_code == 200
+    user_name = Config.FUNCTIONAL_TEST_EMAIL
+    password = Config.FUNCTIONAL_TEST_PASSWORD
+    assert user_name is not None
+    data = {'email_address': user_name,
+            'password': password,
+            'csrf_token': token}
+    post_sign_in_resp = client.post(base_url + '/sign-in', data=data,
+                                    headers=dict(Referer=base_url+'/sign-in'))
+    assert post_sign_in_resp.status_code == 200
 
-        get_two_factor = client.get(base_url + '/two-factor')
-        assert get_two_factor.status_code == 200
-        assert 'Text verification – GOV.UK Notify' == find_page_title(get_two_factor.text)
-        next_token = find_csrf_token(get_two_factor.text)
+    get_two_factor = client.get(base_url + '/two-factor')
+    assert get_two_factor.status_code == 200
+    assert 'Text verification – GOV.UK Notify' == find_page_title(get_two_factor.text)
+    next_token = find_csrf_token(get_two_factor.text)
 
-        # Test will fail if there is not 1 message (we expect only 1 message)
-        messages = retrieve_sms_with_wait(user_name)
-        assert len(messages) == 1, 'Expecting to retrieve 1 sms message in functional test for user: {}'.format(
-            user_name)
+    # Test will fail if there is no sms_code delivered after 12 attempts
+    sms_code = get_sms_via_heroku(client)
 
-        # try to use verify code from message
-        m = messages[0]
-        two_factor_data = {'sms_code': m.body,
-                           'csrf_token': next_token}
-        post_two_factor = client.post(base_url + '/two-factor', data=two_factor_data,
-                                      headers=dict(Referer=base_url+'/two-factor'))
-        assert post_two_factor.status_code == 200
-        assert 'Preview' in post_two_factor.text
-        assert 'dashboard' in post_two_factor.url
-        delete_sms_message(m.sid)
-        sign_out(client, base_url)
-    finally:
-        # Delete all messages even if the test fails.
-        delete_default_sms()
+    # try to use verify code from message
+    two_factor_data = {'sms_code': sms_code,
+                       'csrf_token': next_token}
+    post_two_factor = client.post(base_url + '/two-factor', data=two_factor_data,
+                                  headers=dict(Referer=base_url+'/two-factor'))
+    assert post_two_factor.status_code == 200
+    assert 'Preview' in post_two_factor.text
+    assert 'dashboard' in post_two_factor.url
+    sign_out(client, base_url)
+

--- a/tests/test_signin_flow.py
+++ b/tests/test_signin_flow.py
@@ -43,9 +43,8 @@ def test_sign_in_journey():
     two_factor_data = {'sms_code': sms_code,
                        'csrf_token': next_token}
     post_two_factor = client.post(base_url + '/two-factor', data=two_factor_data,
-                                  headers=dict(Referer=base_url+'/two-factor'))
+                                  headers=dict(Referer=base_url + '/two-factor'))
     assert post_two_factor.status_code == 200
     assert 'Preview' in post_two_factor.text
     assert 'dashboard' in post_two_factor.url
     sign_out(client, base_url)
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,14 +52,14 @@ def sign_in(client, base_url, email, pwd):
         post_sign_in_resp = client.post(
             base_url + '/sign-in',
             data=data,
-            headers=dict(Referer=base_url+'/sign-in'))
+            headers=dict(Referer=base_url + '/sign-in'))
         get_two_factor = client.get(base_url + '/two-factor')
         next_token = find_csrf_token(get_two_factor.text)
         sms_code = get_sms_via_heroku(client)
         two_factor_data = {'sms_code': sms_code,
                            'csrf_token': next_token}
         post_two_factor = client.post(base_url + '/two-factor', data=two_factor_data,
-                                      headers=dict(Referer=base_url+'/two-factor'))
+                                      headers=dict(Referer=base_url + '/two-factor'))
 
     except:
         pytest.fail("Unable to log in")


### PR DESCRIPTION
- Removed the use of the TwilioRestApi and started using the callback.  
When the Twilio number gets a sms message, it posts the message to https://notify-sms-inbox.herokuapp.com/
The endpoint only keeps a records of the last message posted. The GET request to this endpoint will delete cache of this message as well.
The hope is that the stability of the functional tests will improve. Able to remove a lot of the utils functions.