### PR TITLE
Add separate provider delivery tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ build: dependencies ## Build project
 test: venv ## Run tests
 	sh -e /etc/init.d/xvfb start && ./scripts/run_functional_tests.sh
 
+.PHONY: test-providers
+test-providers: venv ## Run tests
+	sh -e /etc/init.d/xvfb start && ./scripts/run_provider_delivery_tests.sh
+
 .PHONY: generate-env-file
 generate-env-file: ## Generate the environment file for running the tests inside a Docker container
 	scripts/generate_docker_env.sh
@@ -67,6 +71,17 @@ test-with-docker: prepare-docker-runner-image generate-env-file ## Run tests ins
 		--env-file docker.env \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make test
+
+.PHONY: test-providers-with-docker
+test-providers-with-docker: prepare-docker-runner-image generate-env-file ## Run tests inside a Docker container
+	docker run -i --rm \
+		--name "${DOCKER_CONTAINER_PREFIX}-test" \
+		-v `pwd`:/var/project \
+		-e ENVIRONMENT=${ENVIRONMENT} \
+		-e SELENIUM_DRIVER=${SELENIUM_DRIVER} \
+		--env-file docker.env \
+		${DOCKER_BUILDER_IMAGE_NAME} \
+		make test-providers
 
 .PHONY: clean-docker-containers
 clean-docker-containers: ## Clean up any remaining docker containers

--- a/scripts/run_provider_delivery_tests.sh
+++ b/scripts/run_provider_delivery_tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Run project tests
+#
+# NOTE: This script expects to be run from the project root with
+# ./scripts/run_provider_delivery_tests.sh
+
+# Use default environment vars for localhost if not already set
+
+set -o pipefail
+[ "$IGNORE_ENVIRONMENT_SH" = "1" ] || source environment.sh 2> /dev/null
+
+function display_result {
+  RESULT=$1
+  EXIT_STATUS=$2
+  TEST=$3
+
+  if [ $RESULT -ne 0 ]; then
+    echo -e "\033[31m$TEST failed\033[0m"
+    exit $EXIT_STATUS
+  else
+    echo -e "\033[32m$TEST passed\033[0m"
+  fi
+}
+
+if [ -d venv ]; then
+  source ./venv/bin/activate
+fi
+
+pep8 --exclude=venv .
+display_result $? 1 "Code style check"
+
+# default env to master (i.e. preview)
+environment=${ENVIRONMENT:=master}
+export ENVIRONMENT=$environment
+
+
+# get status page for env under tests and spit out to console
+function display_status {
+  url=$ENVIRONMENT'_NOTIFY_ADMIN_URL'
+  echo 'Build info:'
+  curl -sSL ${!url}/'_status'
+  echo
+}
+
+
+echo Running $ENVIRONMENT tests
+     display_status $ENVIRONMENT
+     py.test -x tests/provider_delivery/test_provider_delivery.py
+
+
+display_result $? 3 "Unit tests"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from tests.utils import (
     generate_unique_email
 )
 
+from notifications_python_client import NotificationsAPIClient
+
 from tests.pages.rollups import sign_in
 
 from config import Config
@@ -120,3 +122,9 @@ def base_url():
 @pytest.fixture(scope="module")
 def login_user(driver, profile):
     sign_in(driver, profile)
+
+
+@pytest.fixture(scope="module")
+def client(profile):
+    client = NotificationsAPIClient(profile.notify_api_url, profile.service_id, profile.api_key)
+    return client

--- a/tests/provider_delivery/test_provider_delivery.py
+++ b/tests/provider_delivery/test_provider_delivery.py
@@ -1,0 +1,41 @@
+from notifications_python_client import NotificationsAPIClient
+
+from tests.utils import get_delivered_notification
+
+
+def test_provider_delivery(profile):
+    # sms message is delivered within 3 minutes
+    # email message is delivered within 3 minutes
+
+    client = NotificationsAPIClient(profile.notify_api_url,
+                                    profile.service_id,
+                                    profile.api_key)
+
+    # send_sms_via_api(client, profile)
+    send_email_via_api(client, profile)
+
+
+def send_sms_via_api(client, profile):
+    resp_json = client.send_sms_notification(profile.mobile, profile.sms_template_id)
+    message, notification_id = _assert_notification_status(client, profile, resp_json)
+    assert_notification_body(client, message, notification_id)
+
+
+def send_email_via_api(client, profile):
+    print('sending email')
+    resp_json = client.send_email_notification(profile.email, profile.email_template_id)
+    message, notification_id = _assert_notification_status(client, profile, resp_json)
+    assert_notification_body(client, message, notification_id)
+
+
+def _assert_notification_status(client, profile, resp_json):
+    notification_id = resp_json['data']['notification']['id']
+    expected_status = 'delivered'
+    message = get_delivered_notification(client, notification_id, expected_status)
+    return message, notification_id
+
+
+def assert_notification_body(client, message, notification_id):
+    assert "The quick brown fox jumped over the lazy dog" in message
+    resp_json = client.get_notification_by_id(notification_id)
+    assert resp_json['data']['notification']['id'] == notification_id

--- a/tests/staging_live/test_for_live_staging_smoke.py
+++ b/tests/staging_live/test_for_live_staging_smoke.py
@@ -1,7 +1,8 @@
 from tests.utils import (
     create_temp_csv,
     get_notification_via_api,
-    get_delivered_notification)
+    get_delivered_notification,
+    assert_notification_body)
 
 from tests.pages import UploadCsvPage
 
@@ -66,9 +67,3 @@ def _assert_notification_status(client, profile, resp_json):
     expected_status = 'sending' if profile.env == 'dev' else 'delivered'
     message = get_delivered_notification(client, notification_id, expected_status)
     return message, notification_id
-
-
-def assert_notification_body(client, message, notification_id):
-    assert "The quick brown fox jumped over the lazy dog" in message
-    resp_json = client.get_notification_by_id(notification_id)
-    assert resp_json['data']['notification']['id'] == notification_id

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -220,7 +220,7 @@ def do_test_python_client_sms(profile, test_ids):
     expected_status = 'sending' if profile.env == 'dev' else 'delivered'
     message = get_delivered_notification(client, notification_id, expected_status)
 
-    assert "The quick brown fox jumped over the lazy dog" in message
+    assert "The quick brown fox jumped over the lazy dog" in message['body']
 
 
 def do_test_python_client_email(profile, test_ids):
@@ -239,7 +239,7 @@ def do_test_python_client_email(profile, test_ids):
         notification_id = resp_json['data']['notification']['id']
         expected_status = 'sending' if profile.env == 'dev' else 'delivered'
         message = get_delivered_notification(client, notification_id, expected_status)
-        assert "The quick brown fox jumped over the lazy dog" in message
+        assert "The quick brown fox jumped over the lazy dog" in message['body']
     finally:
         remove_all_emails(email_folder=profile.email_notification_label)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -95,6 +95,12 @@ def assert_no_email_present(profile, email_folder):
             gimap.logout()
 
 
+def assert_notification_body(client, message, notification_id):
+    assert "The quick brown fox jumped over the lazy dog" in message["body"]
+    resp_json = client.get_notification_by_id(notification_id)
+    assert resp_json['data']['notification']['id'] == notification_id
+
+
 @retry(RetryException, tries=Config.EMAIL_TRIES, delay=Config.EMAIL_DELAY)
 def get_delivered_notification(client, notification_id, expected_status):
     """
@@ -117,7 +123,7 @@ def get_delivered_notification(client, notification_id, expected_status):
     if status != expected_status:
         raise RetryException('Notification still in {}'.format(status))
     assert status == expected_status
-    return resp_json['data']['notification']['body']
+    return resp_json['data']['notification']
 
 
 def generate_unique_email(email, uuid):


### PR DESCRIPTION
This PR includes additional tests to check if the provider fails for sending notifications via the API and general refactoring.

The Makefile has also been adjusted to include the ability to run these inside a docker container.