### PR TITLE
Add validation to ensure correct notification is returned after csv upload

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -58,6 +58,7 @@ class EditTemplatePageLocators(object):
 class UploadCsvLocators(object):
     FILE_INPUT = (By.ID, 'file')
     SEND_BUTTON = (By.CLASS_NAME, 'button')
+    FIRST_NOTIFICATION_AFTER_UPLOAD = (By.CLASS_NAME, 'table-row')
 
 
 class TeamMembersPageLocators(object):

--- a/tests/staging_live/test_for_live_staging_smoke.py
+++ b/tests/staging_live/test_for_live_staging_smoke.py
@@ -1,7 +1,8 @@
 from tests.utils import (
     create_temp_csv,
-    get_notification_via_api,
-    get_delivered_notification)
+    get_notification_by_id_via_api,
+    get_delivered_notification,
+    assert_notification_body)
 
 from tests.pages import UploadCsvPage
 
@@ -10,10 +11,8 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 def test_for_live_staging_smoke(driver, base_url, profile, login_user):
     upload_csv_page = UploadCsvPage(driver)
-
-    email_via_csv(profile, upload_csv_page)
-    sms_via_csv(profile, upload_csv_page)
-
+    send_notification_via_csv(profile, upload_csv_page, 'sms')
+    send_notification_via_csv(profile, upload_csv_page, 'email')
     upload_csv_page.sign_out()
 
     client = NotificationsAPIClient(profile.notify_api_url,
@@ -24,27 +23,28 @@ def test_for_live_staging_smoke(driver, base_url, profile, login_user):
     send_email_via_api(client, profile)
 
 
-def sms_via_csv(profile, upload_csv_page):
-    # go to upload csv for sms notification page
-    upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
-                                                              profile.sms_template_id)
-    # create csv file to use for sms notification
-    directory, filename = create_temp_csv(profile.mobile, 'phone number')
-    upload_csv_page.upload_csv(directory, filename)
-    message = get_notification_via_api(profile.service_id, profile.sms_template_id,
-                                       profile.env, profile.api_key, profile.mobile)
-    assert "The quick brown fox jumped over the lazy dog" in message
+def send_notification_via_csv(profile, upload_csv_page, message_type):
+    if message_type == 'sms':
+        template_id = profile.sms_template_id
+        directory, filename = create_temp_csv(profile.mobile, 'phone number')
+        to = profile.mobile
+    elif message_type == 'email':
+        template_id = profile.email_template_id
+        directory, filename = create_temp_csv(profile.email, 'email address')
+        to = profile.email
 
-
-def email_via_csv(profile, upload_csv_page):
     upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
-                                                              profile.email_template_id)
-    # create csv file to use for email notification
-    directory, filename = create_temp_csv(profile.email, 'email address')
+                                                              template_id)
     upload_csv_page.upload_csv(directory, filename)
-    email_body = get_notification_via_api(profile.service_id, profile.email_template_id,
-                                          profile.env, profile.api_key, profile.email)
-    assert "The quick brown fox jumped over the lazy dog" in email_body
+    notification_id = upload_csv_page.get_notification_id_after_upload()
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  profile.service_id,
+                                                  template_id,
+                                                  profile.api_key,
+                                                  to)
+
+    assert notification["id"] == notification_id
+    assert "The quick brown fox jumped over the lazy dog" in notification["body"]
 
 
 def send_sms_via_api(client, profile):
@@ -55,9 +55,7 @@ def send_sms_via_api(client, profile):
 
 def send_email_via_api(client, profile):
     resp_json = client.send_email_notification(profile.email, profile.email_template_id)
-
     message, notification_id = _assert_notification_status(client, profile, resp_json)
-
     assert_notification_body(client, message, notification_id)
 
 

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -107,10 +107,17 @@ def do_send_email_from_csv(driver, profile, test_ids):
 
     upload_csv_page = UploadCsvPage(driver)
     upload_csv_page.upload_csv(directory, filename)
-    email_body = get_notification_via_api(test_ids['service_id'], test_ids['email_template_id'],
-                                          profile.env, test_ids['api_key'], profile.email)
+    notification_id = upload_csv_page.get_notification_id_after_upload()
 
-    assert "The quick brown fox jumped over the lazy dog" in email_body
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  test_ids['service_id'],
+                                                  test_ids['email_template_id'],
+                                                  test_ids['api_key'],
+                                                  profile.email)
+
+    assert notification['id'] == notification_id
+    assert 'The quick brown fox jumped over the lazy dog' in notification['body']
+
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service()
 
@@ -131,12 +138,16 @@ def do_send_sms_from_csv(driver, profile, test_ids):
 
     upload_csv_page.upload_csv(directory, filename)
 
-    # we could check the current page and wait for the status
-    # of sending to go to 1, but for the moment get notifications
-    # via api
-    message = get_notification_via_api(service_id, template_id, profile.env, test_ids['api_key'], profile.mobile)
+    notification_id = upload_csv_page.get_notification_id_after_upload()
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  service_id,
+                                                  template_id,
+                                                  test_ids['api_key'],
+                                                  profile.mobile)
 
-    assert "The quick brown fox jumped over the lazy dog" in message
+    assert notification['id'] == notification_id
+    assert 'The quick brown fox jumped over the lazy dog' in notification['body']
+
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service()
 


### PR DESCRIPTION
Currently there are no precise checks to ensure that a notification created via a csv is actually correct. As it stands all notifications are returned and then checks occur to verify (as best as possible) that the notification is correct. 

This pull requests implements functionality to retrieve the notification id after a csv upload and use this to retrieve the notification via the api and then verify its contents.

