### PR TITLE
Add validation to ensure correct notification is returned after csv upload 

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -58,6 +58,7 @@ class EditTemplatePageLocators(object):
 class UploadCsvLocators(object):
     FILE_INPUT = (By.ID, 'file')
     SEND_BUTTON = (By.CLASS_NAME, 'button')
+    FIRST_NOTIFICATION_AFTER_UPLOAD = (By.CLASS_NAME, 'table-row')
 
 
 class TeamMembersPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -318,8 +318,6 @@ class UploadCsvPage(BasePage):
         element.click()
 
     def upload_csv(self, directory, path):
-        import pdb
-        pdb.set_trace()
         file_path = os.path.join(directory, 'sample.csv')
         self.file_input_element = file_path
         self.click_send()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -318,6 +318,8 @@ class UploadCsvPage(BasePage):
         element.click()
 
     def upload_csv(self, directory, path):
+        import pdb
+        pdb.set_trace()
         file_path = os.path.join(directory, 'sample.csv')
         self.file_input_element = file_path
         self.click_send()

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -4,10 +4,6 @@ from tests.utils import create_temp_csv, RetryException
 from notifications_python_client.errors import HTTPError
 
 
-class RetryException(Exception):
-    pass
-
-
 def send_notification_via_api(client, template_id, to, message_type):
     if message_type == 'sms':
         # resp_json = client.send_sms_notification(profile.mobile, profile.sms_template_id)

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -1,0 +1,53 @@
+from retry import retry
+from config import Config
+from tests.utils import create_temp_csv, RetryException
+from notifications_python_client.errors import HTTPError
+
+
+class RetryException(Exception):
+    pass
+
+
+def send_notification_via_api(client, template_id, to, message_type):
+    if message_type == 'sms':
+        # resp_json = client.send_sms_notification(profile.mobile, profile.sms_template_id)
+        resp_json = client.send_sms_notification(to, template_id)
+    elif message_type == 'email':
+        # resp_json = client.send_email_notification(profile.email, profile.email_template_id)
+        resp_json = client.send_email_notification(to, template_id)
+
+    return resp_json['data']['notification']['id']
+
+
+def send_notification_via_csv(profile, upload_csv_page, message_type):
+    if message_type == 'sms':
+        template_id = profile.sms_template_id
+        directory, filename = create_temp_csv(profile.mobile, 'phone number')
+        to = profile.mobile
+    elif message_type == 'email':
+        template_id = profile.email_template_id
+        directory, filename = create_temp_csv(profile.email, 'email address')
+        to = profile.email
+
+    upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
+                                                              template_id)
+    upload_csv_page.upload_csv(directory, filename)
+    notification_id = upload_csv_page.get_notification_id_after_upload()
+
+    return notification_id
+
+
+@retry(RetryException, tries=15, delay=Config.EMAIL_DELAY)
+def get_notification_by_id_via_api(client, notification_id, expected_statuses):
+    try:
+        resp = client.get_notification_by_id(notification_id)
+        notification_status = resp['data']['notification']['status']
+        if notification_status not in expected_statuses:
+            raise RetryException('Notification still in {}'.format(notification_status))
+        return resp["data"]["notification"]
+    except HTTPError as e:
+        if e.status_code == 404:
+            message = 'Notification not created yet for id: {}'.format(notification_id)
+            raise RetryException(message)
+        else:
+            raise

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -6,10 +6,8 @@ from notifications_python_client.errors import HTTPError
 
 def send_notification_via_api(client, template_id, to, message_type):
     if message_type == 'sms':
-        # resp_json = client.send_sms_notification(profile.mobile, profile.sms_template_id)
         resp_json = client.send_sms_notification(to, template_id)
     elif message_type == 'email':
-        # resp_json = client.send_email_notification(profile.email, profile.email_template_id)
         resp_json = client.send_email_notification(to, template_id)
 
     return resp_json['data']['notification']['id']
@@ -19,11 +17,9 @@ def send_notification_via_csv(profile, upload_csv_page, message_type):
     if message_type == 'sms':
         template_id = profile.sms_template_id
         directory, filename = create_temp_csv(profile.mobile, 'phone number')
-        to = profile.mobile
     elif message_type == 'email':
         template_id = profile.email_template_id
         directory, filename = create_temp_csv(profile.email, 'email address')
-        to = profile.email
 
     upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
                                                               template_id)

--- a/tests/staging_live/test_for_live_staging_smoke.py
+++ b/tests/staging_live/test_for_live_staging_smoke.py
@@ -1,66 +1,36 @@
-from tests.utils import (
-    create_temp_csv,
-    get_notification_by_id_via_api,
-    get_delivered_notification,
-    assert_notification_body)
+import pytest
 
 from tests.pages import UploadCsvPage
 
-from notifications_python_client.notifications import NotificationsAPIClient
+from tests.postman import (
+    send_notification_via_api,
+    send_notification_via_csv,
+    get_notification_by_id_via_api
+)
+
+from tests.utils import assert_notification_body
 
 
-def test_for_live_staging_smoke(driver, base_url, profile, login_user):
+def test_for_live_staging_smoke(driver, base_url, client, profile, login_user):
     upload_csv_page = UploadCsvPage(driver)
-    send_notification_via_csv(profile, upload_csv_page, 'sms')
-    send_notification_via_csv(profile, upload_csv_page, 'email')
+    csv_sms_notification_id = send_notification_via_csv(profile, upload_csv_page, 'sms')
+    csv_sms_notification = get_notification_by_id_via_api(client, csv_sms_notification_id, ['sending', 'delivered'])
+    assert_notification_body(csv_sms_notification_id, csv_sms_notification)
+
+    csv_email_notification_id = send_notification_via_csv(profile, upload_csv_page, 'email')
+    csv_email_notification = get_notification_by_id_via_api(client, csv_email_notification_id, ['sending', 'delivered'])
+    assert_notification_body(csv_email_notification_id, csv_email_notification)
+
     upload_csv_page.sign_out()
 
-    client = NotificationsAPIClient(profile.notify_api_url,
-                                    profile.service_id,
-                                    profile.api_key)
 
-    send_sms_via_api(client, profile)
-    send_email_via_api(client, profile)
-
-
-def send_notification_via_csv(profile, upload_csv_page, message_type):
-    if message_type == 'sms':
-        template_id = profile.sms_template_id
-        directory, filename = create_temp_csv(profile.mobile, 'phone number')
-        to = profile.mobile
-    elif message_type == 'email':
-        template_id = profile.email_template_id
-        directory, filename = create_temp_csv(profile.email, 'email address')
-        to = profile.email
-
-    upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
-                                                              template_id)
-    upload_csv_page.upload_csv(directory, filename)
-    notification_id = upload_csv_page.get_notification_id_after_upload()
-    notification = get_notification_by_id_via_api(notification_id,
-                                                  profile.service_id,
-                                                  template_id,
-                                                  profile.api_key,
-                                                  to)
-
-    assert notification["id"] == notification_id
-    assert "The quick brown fox jumped over the lazy dog" in notification["body"]
-
-
-def send_sms_via_api(client, profile):
-    resp_json = client.send_sms_notification(profile.mobile, profile.sms_template_id)
-    message, notification_id = _assert_notification_status(client, profile, resp_json)
-    assert_notification_body(client, message, notification_id)
-
-
-def send_email_via_api(client, profile):
-    resp_json = client.send_email_notification(profile.email, profile.email_template_id)
-    message, notification_id = _assert_notification_status(client, profile, resp_json)
-    assert_notification_body(client, message, notification_id)
-
-
-def _assert_notification_status(client, profile, resp_json):
-    notification_id = resp_json['data']['notification']['id']
-    expected_status = 'sending' if profile.env == 'dev' else 'delivered'
-    message = get_delivered_notification(client, notification_id, expected_status)
-    return message, notification_id
+@pytest.mark.parametrize('message_type, expected_statuses', [
+    ('sms', ['sending', 'delivered']),
+    ('email', ['sending', 'delivered'])
+])
+def test_send_sms_and_email_via_api(profile, client, message_type, expected_statuses):
+    template_id = profile.sms_template_id if message_type == 'sms' else profile.email_template_id
+    to = profile.mobile if message_type == 'sms' else profile.email
+    notification_id = send_notification_via_api(client, template_id, to, message_type)
+    notification = get_notification_by_id_via_api(client, notification_id, expected_statuses)
+    assert_notification_body(notification_id, notification)

--- a/tests/staging_live/test_for_live_staging_smoke.py
+++ b/tests/staging_live/test_for_live_staging_smoke.py
@@ -1,6 +1,6 @@
 from tests.utils import (
     create_temp_csv,
-    get_notification_via_api,
+    get_notification_by_id_via_api,
     get_delivered_notification,
     assert_notification_body)
 
@@ -11,10 +11,8 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 def test_for_live_staging_smoke(driver, base_url, profile, login_user):
     upload_csv_page = UploadCsvPage(driver)
-
-    email_via_csv(profile, upload_csv_page)
-    sms_via_csv(profile, upload_csv_page)
-
+    send_notification_via_csv(profile, upload_csv_page, 'sms')
+    send_notification_via_csv(profile, upload_csv_page, 'email')
     upload_csv_page.sign_out()
 
     client = NotificationsAPIClient(profile.notify_api_url,
@@ -25,27 +23,28 @@ def test_for_live_staging_smoke(driver, base_url, profile, login_user):
     send_email_via_api(client, profile)
 
 
-def sms_via_csv(profile, upload_csv_page):
-    # go to upload csv for sms notification page
-    upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
-                                                              profile.sms_template_id)
-    # create csv file to use for sms notification
-    directory, filename = create_temp_csv(profile.mobile, 'phone number')
-    upload_csv_page.upload_csv(directory, filename)
-    message = get_notification_via_api(profile.service_id, profile.sms_template_id,
-                                       profile.env, profile.api_key, profile.mobile)
-    assert "The quick brown fox jumped over the lazy dog" in message
+def send_notification_via_csv(profile, upload_csv_page, message_type):
+    if message_type == 'sms':
+        template_id = profile.sms_template_id
+        directory, filename = create_temp_csv(profile.mobile, 'phone number')
+        to = profile.mobile
+    elif message_type == 'email':
+        template_id = profile.email_template_id
+        directory, filename = create_temp_csv(profile.email, 'email address')
+        to = profile.email
 
-
-def email_via_csv(profile, upload_csv_page):
     upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
-                                                              profile.email_template_id)
-    # create csv file to use for email notification
-    directory, filename = create_temp_csv(profile.email, 'email address')
+                                                              template_id)
     upload_csv_page.upload_csv(directory, filename)
-    email_body = get_notification_via_api(profile.service_id, profile.email_template_id,
-                                          profile.env, profile.api_key, profile.email)
-    assert "The quick brown fox jumped over the lazy dog" in email_body
+    notification_id = upload_csv_page.get_notification_id_after_upload()
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  profile.service_id,
+                                                  template_id,
+                                                  profile.api_key,
+                                                  to)
+
+    assert notification["id"] == notification_id
+    assert "The quick brown fox jumped over the lazy dog" in notification["body"]
 
 
 def send_sms_via_api(client, profile):
@@ -56,9 +55,7 @@ def send_sms_via_api(client, profile):
 
 def send_email_via_api(client, profile):
     resp_json = client.send_email_notification(profile.email, profile.email_template_id)
-
     message, notification_id = _assert_notification_status(client, profile, resp_json)
-
     assert_notification_body(client, message, notification_id)
 
 

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -16,7 +16,9 @@ from tests.utils import (
     do_verify,
     assert_no_email_present,
     get_delivered_notification,
-    get_notification_via_api)
+    get_notification_via_api,
+    get_notification_by_id_via_api
+)
 
 from tests.pages import (
     MainPage,

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -107,10 +107,17 @@ def do_send_email_from_csv(driver, profile, test_ids):
 
     upload_csv_page = UploadCsvPage(driver)
     upload_csv_page.upload_csv(directory, filename)
-    email_body = get_notification_via_api(test_ids['service_id'], test_ids['email_template_id'],
-                                          profile.env, test_ids['api_key'], profile.email)
+    notification_id = upload_csv_page.get_notification_id_after_upload()
 
-    assert "The quick brown fox jumped over the lazy dog" in email_body
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  test_ids['service_id'],
+                                                  test_ids['email_template_id'],
+                                                  test_ids['api_key'],
+                                                  profile.email)
+
+    assert notification['id'] == notification_id
+    assert 'The quick brown fox jumped over the lazy dog' in notification['body']
+
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service()
 
@@ -131,12 +138,16 @@ def do_send_sms_from_csv(driver, profile, test_ids):
 
     upload_csv_page.upload_csv(directory, filename)
 
-    # we could check the current page and wait for the status
-    # of sending to go to 1, but for the moment get notifications
-    # via api
-    message = get_notification_via_api(service_id, template_id, profile.env, test_ids['api_key'], profile.mobile)
+    notification_id = upload_csv_page.get_notification_id_after_upload()
+    notification = get_notification_by_id_via_api(notification_id,
+                                                  service_id,
+                                                  template_id,
+                                                  test_ids['api_key'],
+                                                  profile.mobile)
 
-    assert "The quick brown fox jumped over the lazy dog" in message
+    assert notification['id'] == notification_id
+    assert 'The quick brown fox jumped over the lazy dog' in notification['body']
+
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service()
 

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -1,4 +1,3 @@
-import pytest
 import uuid
 
 from tests.pages.rollups import get_service_templates_and_api_key_for_tests
@@ -7,7 +6,9 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 from config import Config
 
-from tests.postman import send_notification_via_api, get_notification_by_id_via_api
+from tests.postman import (
+    send_notification_via_api,
+    get_notification_by_id_via_api)
 
 from tests.utils import (
     get_link,
@@ -16,7 +17,6 @@ from tests.utils import (
     remove_all_emails,
     generate_unique_email,
     do_verify,
-    assert_no_email_present,
     assert_notification_body,
     )
 
@@ -80,7 +80,8 @@ def do_user_registration(driver, base_url, profile):
     assert driver.current_url == base_url + '/registration-continue'
 
     registration_link = get_link(profile, profile.registration_email_label,
-                                 profile.registration_template_id, profile.email)
+                                 profile.registration_template_id,
+                                 profile.email)
 
     driver.get(registration_link)
 
@@ -114,7 +115,11 @@ def do_send_email_from_csv(driver, profile, test_ids):
     client = NotificationsAPIClient(Config.NOTIFY_API_URL,
                                     test_ids['service_id'],
                                     test_ids['api_key'])
-    notification = get_notification_by_id_via_api(client, notification_id, ['sending', 'delivered'])
+
+    notification = get_notification_by_id_via_api(client,
+                                                  notification_id,
+                                                  ['sending', 'delivered'])
+
     assert_notification_body(notification_id, notification)
 
     dashboard_page = DashboardPage(driver)
@@ -124,7 +129,6 @@ def do_send_email_from_csv(driver, profile, test_ids):
 def do_send_sms_from_csv(driver, profile, test_ids):
 
     dashboard_page = DashboardPage(driver)
-    service_id = dashboard_page.get_service_id()
     dashboard_page.click_sms_templates()
 
     send_sms_page = SendSmsTemplatePage(driver)
@@ -133,7 +137,6 @@ def do_send_sms_from_csv(driver, profile, test_ids):
     directory, filename = create_temp_csv(profile.mobile, 'phone number')
 
     upload_csv_page = UploadCsvPage(driver)
-    template_id = upload_csv_page.get_template_id()
 
     upload_csv_page.upload_csv(directory, filename)
 
@@ -141,7 +144,9 @@ def do_send_sms_from_csv(driver, profile, test_ids):
                                     test_ids['service_id'],
                                     test_ids['api_key'])
     notification_id = upload_csv_page.get_notification_id_after_upload()
-    notification = get_notification_by_id_via_api(client, notification_id, ['sending', 'delivered'])
+    notification = get_notification_by_id_via_api(client,
+                                                  notification_id,
+                                                  ['sending', 'delivered'])
 
     assert_notification_body(notification_id, notification)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,9 +5,9 @@ import re
 import pytest
 
 from retry import retry
-from notifications_python_client.errors import HTTPError
 from notifications_python_client.notifications import NotificationsAPIClient
 from config import Config
+
 from tests.pages import VerifyPage
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,18 +2,13 @@ import csv
 import email as email_lib
 import imaplib
 import re
-
 import pytest
+
+from retry import retry
 from notifications_python_client.errors import HTTPError
 from notifications_python_client.notifications import NotificationsAPIClient
-from retry import retry
-
 from config import Config
 from tests.pages import VerifyPage
-
-
-class RetryException(Exception):
-    pass
 
 
 def remove_all_emails(email=None, pwd=None, email_folder=None):
@@ -49,6 +44,10 @@ def create_temp_csv(number, field_name):
         csv_writer.writeheader()
         csv_writer.writerow({field_name: number})
     return directory_name, 'sample.csv'
+
+
+class RetryException(Exception):
+    pass
 
 
 @retry(RetryException, tries=Config.EMAIL_TRIES, delay=Config.EMAIL_DELAY)


### PR DESCRIPTION
Currently there are no precise checks to ensure that a notification created via a csv is actually correct. As it stands all notifications are returned and then checks occur to verify (as best as possible) that the notification is correct.

This pull requests implements functionality to retrieve the notification id after a csv upload and use this to retrieve the notification via the api and then verify its contents.