### PR TITLE
Update for changed location of API keys page

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -75,6 +75,7 @@ class InviteUserPageLocators(object):
 
 class ApiKeysPageLocators(object):
     KEY_NAME_INPUT = (By.NAME, 'key_name')
+    KEYS_PAGE_LINK = (By.LINK_TEXT, 'API keys')
     CREATE_KEY_LINK = (By.LINK_TEXT, 'Create an API key')
     API_KEY_ELEMENT = (By.CLASS_NAME, 'api-key-key')
     NORMAL_KEY_RADIO = (By.XPATH, "//input[@value='normal']")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -411,6 +411,7 @@ class ProfilePage(BasePage):
 class ApiKeyPage(BasePage):
 
     key_name_input = KeyNameInputElement()
+    keys_link = ApiKeysPageLocators.KEYS_PAGE_LINK
     create_key_link = ApiKeysPageLocators.CREATE_KEY_LINK
     continue_button = CommonPageLocators.CONTINUE_BUTTON
     api_key_element = ApiKeysPageLocators.API_KEY_ELEMENT
@@ -422,6 +423,10 @@ class ApiKeyPage(BasePage):
 
     def enter_key_name(self, key_type='normal'):
         self.key_name_input = 'Test ' + key_type
+
+    def click_keys_link(self):
+        element = self.wait_for_element(ApiKeyPage.keys_link)
+        element.click()
 
     def click_create_key(self):
         element = self.wait_for_element(ApiKeyPage.create_key_link)

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -58,6 +58,7 @@ def get_service_templates_and_api_key_for_tests(driver, test_profile):
     dashboard_page.click_api_keys_link()
 
     api_key_page = ApiKeyPage(driver)
+    api_key_page.click_keys_link()
     api_key_page.click_create_key()
 
     api_key_page.click_key_type_radio(key_type='normal')

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -264,6 +264,7 @@ def create_api_key(driver, key_type):
     dashboard_page.click_api_keys_link()
 
     api_key_page = ApiKeyPage(driver)
+    api_key_page.click_keys_link()
     api_key_page.click_create_key()
 
     api_key_page.click_key_type_radio(key_type)


### PR DESCRIPTION
The API keys page is now one level further down, behind the API Integration page. This was changed in: https://github.com/alphagov/notifications-admin/pull/949

This commit adds an extra step to click through to the right page.