### PR TITLE
Remove line causing docker to share network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ build-with-docker: prepare-docker-runner-image ## Build inside a Docker containe
 
 .PHONY: run-docker-image
 run-docker-image: prepare-docker-runner-image generate-env-file ## Run tests inside a Docker container
-	docker run -i -d --network=host \
+	docker run -i -d \
 		--name "${DOCKER_CONTAINER_PREFIX}-test" \
 		-v `pwd`:/var/project \
 		-e ENVIRONMENT=${ENVIRONMENT} \


### PR DESCRIPTION
Functional tests were failing when attempting to access localhost. This stops the docker container sharing the network with the host machine (should only have been used for local dev).