### PR TITLE
Use team key for functional tests

### DIFF
--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -61,8 +61,8 @@ def get_service_templates_and_api_key_for_tests(driver, test_profile):
     api_key_page.click_keys_link()
     api_key_page.click_create_key()
 
-    api_key_page.click_key_type_radio(key_type='normal')
-    api_key_page.enter_key_name(key_type='normal')
+    api_key_page.click_key_type_radio(key_type='team')
+    api_key_page.enter_key_name(key_type='team')
 
     api_key_page.click_continue()
     api_key = api_key_page.get_api_key()


### PR DESCRIPTION
Services in trial mode can’t create normal keys any more. There’s not even the option on the page (since https://github.com/alphagov/notifications-admin/pull/969). This was causing the tests to fail.