### PR TITLE
Refactor preview tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,8 +16,6 @@ class Config(object):
     EMAIL_TRIES = 36
     EMAIL_DELAY = 5
     RETRY_DELAY = 5
-    SMS_TEMPLATE_ID = os.environ[os.environ['ENVIRONMENT'] + '_SMS_TEMPLATE_ID']
-    EMAIL_TEMPLATE_ID = os.environ[os.environ['ENVIRONMENT'] + '_EMAIL_TEMPLATE_ID']
     FUNCTIONAL_TEST_SERVICE_NAME = os.environ['ENVIRONMENT'] + '_Functional Test Service_'
     NOTIFY_SERVICE_ID = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_ID']
     NOTIFY_SERVICE_API_KEY = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_API_KEY']

--- a/config.py
+++ b/config.py
@@ -15,12 +15,24 @@ class Config(object):
     INVITATION_EMAIL_LABEL = 'invite'
     EMAIL_TRIES = 36
     EMAIL_DELAY = 5
+    RETRY_DELAY = 5
+    SMS_TEMPLATE_ID = os.environ[os.environ['ENVIRONMENT'] + '_SMS_TEMPLATE_ID']
+    EMAIL_TEMPLATE_ID = os.environ[os.environ['ENVIRONMENT'] + '_EMAIL_TEMPLATE_ID']
     FUNCTIONAL_TEST_SERVICE_NAME = os.environ['ENVIRONMENT'] + '_Functional Test Service_'
     NOTIFY_SERVICE_ID = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_ID']
     NOTIFY_SERVICE_API_KEY = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_API_KEY']
     REGISTRATION_TEMPLATE_ID = 'ece42649-22a8-4d06-b87f-d52d5d3f0a27'
     INVITATION_TEMPLATE_ID = '4f46df42-f795-4cc4-83bb-65ca312f49cc'
     VERIFY_CODE_TEMPLATE_ID = '36fb0730-6259-4da1-8a80-c8de22ad4246'
+
+
+class PreviewConfig(Config):
+    SMS_TEMPLATE_ID = os.environ.get('preview_SMS_TEMPLATE_ID')
+    EMAIL_TEMPLATE_ID = os.environ.get('preview_EMAIL_TEMPLATE_ID')
+    NOTIFY_RESEARCH_MODE_EMAIL = os.environ.get('preview_NOTIFY_RESEARCH_MODE_EMAIL')
+    NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD = os.environ.get('preview_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD')
+    NOTIFY_RESEARCH_SERVICE_ID = os.environ.get('preview_NOTIFY_RESEARCH_SERVICE_ID')
+    NOTIFY_RESEARCH_SERVICE_API_KEY = os.environ.get('preview_NOTIFY_RESEARCH_SERVICE_API_KEY')
 
 
 class StagingConfig(Config):

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -56,7 +56,7 @@ case $ENVIRONMENT in
       display_status $ENVIRONMENT
       py.test -x tests/admin/test_admin_with_seeded_user.py
       ;;
-    master|*)
+    *)
       echo 'Default test run - for' $ENVIRONMENT
       display_status $ENVIRONMENT
       py.test -x tests/test_all_the_things.py

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -51,6 +51,11 @@ case $ENVIRONMENT in
       py.test -x tests/notify_api/test_notify_api_email.py
       py.test -x tests/notify_api/test_notify_api_sms.py
       ;;
+    preview)
+      echo Running $ENVIRONMENT tests
+      display_status $ENVIRONMENT
+      py.test -x tests/admin/test_admin_with_seeded_user.py
+      ;;
     master|*)
       echo 'Default test run - for' $ENVIRONMENT
       display_status $ENVIRONMENT

--- a/tests/admin/test_admin_with_seeded_user.py
+++ b/tests/admin/test_admin_with_seeded_user.py
@@ -43,9 +43,8 @@ def test_send_csv(driver, profile, login_seeded_user, seeded_client, message_typ
     dashboard_page.go_to_dashboard_for_service()
 
     dashboard_stats_after = get_dashboard_stats(dashboard_page, message_type, template_id)
-    status = dashboard_page.get_status(message_type)
 
-    assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after, status)
+    assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after)
 
 
 def get_dashboard_stats(dashboard_page, message_type, template_id):
@@ -55,10 +54,9 @@ def get_dashboard_stats(dashboard_page, message_type, template_id):
     }
 
 
-def assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after, status):
+def assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after):
     for k in dashboard_stats_before.keys():
         assert dashboard_stats_after[k] == dashboard_stats_before[k] + 1
-    assert status == 'No failures'
 
 
 def _get_template_count(dashboard_page, template_id):

--- a/tests/admin/test_admin_with_seeded_user.py
+++ b/tests/admin/test_admin_with_seeded_user.py
@@ -1,0 +1,70 @@
+import pytest
+
+from selenium.common.exceptions import TimeoutException
+
+from tests.postman import (
+    send_notification_via_csv,
+    get_notification_by_id_via_api)
+
+
+from tests.utils import (
+    do_user_registration,
+    do_user_can_invite_someone_to_notify,
+    assert_notification_body
+    )
+
+from tests.pages import (
+    DashboardPage,
+    UploadCsvPage
+)
+
+
+def test_registration_and_invite_flow(driver, profile, base_url):
+    do_user_registration(driver, profile, base_url)
+    do_user_can_invite_someone_to_notify(driver, profile)
+
+
+@pytest.mark.parametrize('message_type', ['sms', 'email'])
+def test_send_csv(driver, profile, login_seeded_user, seeded_client, message_type):
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service()
+    template_id = profile.email_template_id if message_type == 'email' else profile.sms_template_id
+
+    dashboard_stats_before = get_dashboard_stats(dashboard_page, message_type, template_id)
+
+    upload_csv_page = UploadCsvPage(driver)
+    notification_id = send_notification_via_csv(profile, upload_csv_page, message_type, seeded=True)
+    notification = get_notification_by_id_via_api(
+        seeded_client,
+        notification_id,
+        ['sending', 'delivered']
+    )
+    assert_notification_body(notification_id, notification)
+    dashboard_page.go_to_dashboard_for_service()
+
+    dashboard_stats_after = get_dashboard_stats(dashboard_page, message_type, template_id)
+    status = dashboard_page.get_status(message_type)
+
+    assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after, status)
+
+
+def get_dashboard_stats(dashboard_page, message_type, template_id):
+    return {
+        'total_messages_sent': dashboard_page.get_total_message_count(message_type),
+        'template_messages_sent': _get_template_count(dashboard_page, template_id)
+    }
+
+
+def assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after, status):
+    for k in dashboard_stats_before.keys():
+        assert dashboard_stats_after[k] == dashboard_stats_before[k] + 1
+    assert status == 'No failures'
+
+
+def _get_template_count(dashboard_page, template_id):
+    try:
+        template_messages_count = dashboard_page.get_template_message_count(template_id)
+    except TimeoutException:
+        return 0  # template count may not exist yet if no messages sent
+    else:
+        return template_messages_count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,8 +116,6 @@ def profile():
                           'email_notification_label': Config.EMAIL_NOTIFICATION_LABEL,
                           'registration_email_label': Config.REGISTRATION_EMAIL_LABEL,
                           'invitation_email_label': Config.INVITATION_EMAIL_LABEL,
-                          'email_template_id': Config.EMAIL_TEMPLATE_ID,
-                          'sms_template_id': Config.SMS_TEMPLATE_ID,
                           'notify_service_id': Config.NOTIFY_SERVICE_ID,
                           'notify_api_url': Config.NOTIFY_API_URL,
                           'notify_service_api_key': Config.NOTIFY_SERVICE_API_KEY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,38 @@ class Profile(object):
 @pytest.fixture(scope="session")
 def profile():
     env = os.environ['ENVIRONMENT'].lower()
-    if env == 'staging':
+
+    if env == 'preview':
+        from config import PreviewConfig
+        uuid_for_test_run = str(uuid.uuid1())
+        functional_test_name = PreviewConfig.FUNCTIONAL_TEST_NAME + uuid_for_test_run
+        functional_test_email = generate_unique_email(PreviewConfig.FUNCTIONAL_TEST_EMAIL, uuid_for_test_run)
+        functional_test_service_name = PreviewConfig.FUNCTIONAL_TEST_SERVICE_NAME + uuid_for_test_run
+        functional_test_password = PreviewConfig.FUNCTIONAL_TEST_PASSWORD
+        functional_test_email_password = PreviewConfig.FUNCTIONAL_TEST_EMAIL_PASSWORD
+        functional_test_mobile = PreviewConfig.TEST_NUMBER
+        return Profile(**{'env': PreviewConfig.ENVIRONMENT,
+                          'name': functional_test_name,
+                          'email': functional_test_email,
+                          'service_name': functional_test_service_name,
+                          'password': functional_test_password,
+                          'email_password': functional_test_email_password,
+                          'mobile': functional_test_mobile,
+                          'email_notification_label': PreviewConfig.EMAIL_NOTIFICATION_LABEL,
+                          'registration_email_label': PreviewConfig.REGISTRATION_EMAIL_LABEL,
+                          'invitation_email_label': PreviewConfig.INVITATION_EMAIL_LABEL,
+                          'email_template_id': PreviewConfig.EMAIL_TEMPLATE_ID,
+                          'sms_template_id': PreviewConfig.SMS_TEMPLATE_ID,
+                          'notify_service_id': PreviewConfig.NOTIFY_SERVICE_ID,
+                          'notify_api_url': PreviewConfig.NOTIFY_API_URL,
+                          'notify_service_api_key': PreviewConfig.NOTIFY_SERVICE_API_KEY,
+                          'notify_research_service_email': PreviewConfig.NOTIFY_RESEARCH_MODE_EMAIL,
+                          'notify_research_service_password': PreviewConfig.NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD,
+                          'notify_research_service_id': PreviewConfig.NOTIFY_RESEARCH_SERVICE_ID,
+                          'notify_research_service_api_key': PreviewConfig.NOTIFY_RESEARCH_SERVICE_API_KEY,
+                          'registration_template_id': PreviewConfig.REGISTRATION_TEMPLATE_ID,
+                          'invitation_template_id': PreviewConfig.INVITATION_TEMPLATE_ID})
+    elif env == 'staging':
         from config import StagingConfig
         return Profile(**{'env': StagingConfig.ENVIRONMENT,
                           'name': StagingConfig.FUNCTIONAL_TEST_NAME,
@@ -85,7 +116,10 @@ def profile():
                           'email_notification_label': Config.EMAIL_NOTIFICATION_LABEL,
                           'registration_email_label': Config.REGISTRATION_EMAIL_LABEL,
                           'invitation_email_label': Config.INVITATION_EMAIL_LABEL,
+                          'email_template_id': Config.EMAIL_TEMPLATE_ID,
+                          'sms_template_id': Config.SMS_TEMPLATE_ID,
                           'notify_service_id': Config.NOTIFY_SERVICE_ID,
+                          'notify_api_url': Config.NOTIFY_API_URL,
                           'notify_service_api_key': Config.NOTIFY_SERVICE_API_KEY,
                           'registration_template_id': Config.REGISTRATION_TEMPLATE_ID,
                           'invitation_template_id': Config.INVITATION_TEMPLATE_ID})
@@ -104,7 +138,7 @@ def driver(request):
     elif driver_name == 'chrome':
         options = webdriver.chrome.options.Options()
         options.add_argument("user-agent=Selenium")
-        driver = webdriver.Chrome(chrome_options=opts)
+        driver = webdriver.Chrome(chrome_options=options)
     else:
         raise ValueError('Invalid Selenium driver', driver_name)
 
@@ -123,12 +157,32 @@ def base_url():
     return Config.NOTIFY_ADMIN_URL
 
 
+@pytest.fixture(scope="session")
+def base_api_url():
+    return Config.NOTIFY_API_URL
+
+
 @pytest.fixture(scope="module")
 def login_user(driver, profile):
     sign_in(driver, profile)
 
 
 @pytest.fixture(scope="module")
+def login_seeded_user(driver, profile):
+    sign_in(driver, profile, True)
+
+
+@pytest.fixture(scope="module")
 def client(profile):
     client = NotificationsAPIClient(profile.notify_api_url, profile.service_id, profile.api_key)
+    return client
+
+
+@pytest.fixture(scope="module")
+def seeded_client(profile):
+    client = NotificationsAPIClient(
+        profile.notify_api_url,
+        profile.notify_research_service_id,
+        profile.notify_research_service_api_key
+    )
     return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def profile():
 
     if env == 'preview':
         from config import PreviewConfig
-        uuid_for_test_run = str(uuid.uuid1())
+        uuid_for_test_run = str(uuid.uuid4())
         functional_test_name = PreviewConfig.FUNCTIONAL_TEST_NAME + uuid_for_test_run
         functional_test_email = generate_unique_email(PreviewConfig.FUNCTIONAL_TEST_EMAIL, uuid_for_test_run)
         functional_test_service_name = PreviewConfig.FUNCTIONAL_TEST_SERVICE_NAME + uuid_for_test_run
@@ -99,7 +99,7 @@ def profile():
                           'invitation_template_id': LiveConfig.INVITATION_TEMPLATE_ID})
     else:
         from config import Config
-        uuid_for_test_run = str(uuid.uuid1())
+        uuid_for_test_run = str(uuid.uuid4())
         functional_test_name = Config.FUNCTIONAL_TEST_NAME + uuid_for_test_run
         functional_test_email = generate_unique_email(Config.FUNCTIONAL_TEST_EMAIL, uuid_for_test_run)
         functional_test_service_name = Config.FUNCTIONAL_TEST_SERVICE_NAME + uuid_for_test_run

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -32,6 +32,14 @@ class DashboardPageLocators(object):
     EMAIL_TEMPLATES_LINK = (By.LINK_TEXT, 'Email templates')
     TEAM_MEMBERS_LINK = (By.LINK_TEXT, 'Team members')
     API_KEYS_LINK = (By.LINK_TEXT, 'API integration')
+    TOTAL_EMAIL_NUMBER = (By.CSS_SELECTOR, '#total-email .big-number-number')
+    TOTAL_SMS_NUMBER = (By.CSS_SELECTOR, '#total-sms .big-number-number')
+    SENT_EMAIL_FAILURE_STATUS = (By.CSS_SELECTOR, '#total-email .big-number-status')
+    SENT_SMS_FAILURE_STATUS = (By.CSS_SELECTOR, '#total-sms .big-number-status')
+
+    @classmethod
+    def messages_sent_count_for_template(self, template_id):
+        return (By.ID, template_id)
 
 
 class NavigationLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -34,8 +34,6 @@ class DashboardPageLocators(object):
     API_KEYS_LINK = (By.LINK_TEXT, 'API integration')
     TOTAL_EMAIL_NUMBER = (By.CSS_SELECTOR, '#total-email .big-number-number')
     TOTAL_SMS_NUMBER = (By.CSS_SELECTOR, '#total-sms .big-number-number')
-    SENT_EMAIL_FAILURE_STATUS = (By.CSS_SELECTOR, '#total-email .big-number-status')
-    SENT_SMS_FAILURE_STATUS = (By.CSS_SELECTOR, '#total-sms .big-number-status')
 
     @classmethod
     def messages_sent_count_for_template(self, template_id):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -177,8 +177,6 @@ class DashboardPage(BasePage):
     api_keys_link = DashboardPageLocators.API_KEYS_LINK
     total_email_div = DashboardPageLocators.TOTAL_EMAIL_NUMBER
     total_sms_div = DashboardPageLocators.TOTAL_SMS_NUMBER
-    sent_email_status_div = DashboardPageLocators.SENT_EMAIL_FAILURE_STATUS
-    sent_sms_status_div = DashboardPageLocators.SENT_SMS_FAILURE_STATUS
 
     def _message_count_for_template_div(self, template_id):
         return DashboardPageLocators.messages_sent_count_for_template(template_id)
@@ -231,14 +229,6 @@ class DashboardPage(BasePage):
         element = self.wait_for_element(messages_sent_count_for_template_div)
 
         return int(element.text)
-
-    def get_status(self, message_type):
-        target_div = (DashboardPage.sent_email_status_div
-                      if message_type == 'email'
-                      else DashboardPage.sent_sms_status_div)
-        element = self.wait_for_element(target_div)
-
-        return element.text
 
 
 class SendSmsTemplatePage(BasePage):

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -11,12 +11,12 @@ from tests.pages import (
 from tests.utils import do_verify
 
 
-def sign_in(driver, test_profile):
+def sign_in(driver, test_profile, seeded=False):
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
     assert sign_in_page.is_current()
-    sign_in_page.login(test_profile)
-    do_verify(driver, test_profile),
+    sign_in_page.login(test_profile, seeded)
+    do_verify(driver, test_profile)
 
 
 def get_service_templates_and_api_key_for_tests(driver, test_profile):
@@ -66,5 +66,10 @@ def get_service_templates_and_api_key_for_tests(driver, test_profile):
 
     api_key_page.click_continue()
     api_key = api_key_page.get_api_key()
+
+    test_profile.service_id = service_id
+    test_profile.email_template_id = email_template_id
+    test_profile.sms_template_id = sms_template_id
+    test_profile.api_key = api_key
 
     return {'service_id': service_id, 'email_template_id': email_template_id, 'sms_template_id': sms_template_id, 'api_key': api_key}  # noqa

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -13,15 +13,18 @@ def send_notification_via_api(client, template_id, to, message_type):
     return resp_json['data']['notification']['id']
 
 
-def send_notification_via_csv(profile, upload_csv_page, message_type):
+def send_notification_via_csv(profile, upload_csv_page, message_type, seeded=False):
+    service_id = profile.notify_research_service_id if seeded else profile.service_id
+    email = profile.notify_research_service_email if seeded else profile.email
+
     if message_type == 'sms':
         template_id = profile.sms_template_id
         directory, filename = create_temp_csv(profile.mobile, 'phone number')
     elif message_type == 'email':
         template_id = profile.email_template_id
-        directory, filename = create_temp_csv(profile.email, 'email address')
+        directory, filename = create_temp_csv(email, 'email address')
 
-    upload_csv_page.go_to_upload_csv_for_service_and_template(profile.service_id,
+    upload_csv_page.go_to_upload_csv_for_service_and_template(service_id,
                                                               template_id)
     upload_csv_page.upload_csv(directory, filename)
     notification_id = upload_csv_page.get_notification_id_after_upload()

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -1,39 +1,21 @@
-import uuid
+from tests.postman import (
+    send_notification_via_csv,
+    get_notification_by_id_via_api)
+
+from tests.utils import (
+    get_email_body,
+    remove_all_emails,
+    do_user_registration,
+    do_user_can_invite_someone_to_notify,
+    do_edit_and_delete_email_template,
+    assert_notification_body
+    )
+
+from tests.pages import UploadCsvPage
 
 from tests.pages.rollups import get_service_templates_and_api_key_for_tests
 
 from notifications_python_client.notifications import NotificationsAPIClient
-
-from config import Config
-
-from tests.postman import (
-    send_notification_via_api,
-    get_notification_by_id_via_api)
-
-from tests.utils import (
-    get_link,
-    create_temp_csv,
-    get_email_body,
-    remove_all_emails,
-    generate_unique_email,
-    do_verify,
-    assert_notification_body,
-    )
-
-from tests.pages import (
-    MainPage,
-    RegistrationPage,
-    DashboardPage,
-    AddServicePage,
-    SendEmailTemplatePage,
-    UploadCsvPage,
-    SendSmsTemplatePage,
-    TeamMembersPage,
-    InviteUserPage,
-    RegisterFromInvite,
-    EditEmailTemplatePage,
-    ApiKeyPage
-)
 
 
 def _get_email_message(profile):
@@ -44,230 +26,29 @@ def _get_email_message(profile):
         remove_all_emails(email_folder=profile.email_notification_label)
 
 
-# Note registration *must* run before any other tests as it registers the user for use
-# in later tests and test_python_client_flow.py needs to run last as it will use templates created
-# by sms and email tests
-def test_everything(driver, base_url, profile):
-    do_user_registration(driver, base_url, profile)
-
-    # TODO move this to profile and setup in conftest
+def test_everything(driver, profile, base_url, base_api_url):
+    do_user_registration(driver, profile, base_url)
     test_ids = get_service_templates_and_api_key_for_tests(driver, profile)
 
-    do_send_email_from_csv(driver, profile, test_ids)
-    do_send_sms_from_csv(driver, profile, test_ids)
+    client = NotificationsAPIClient(base_api_url, test_ids['service_id'], test_ids['api_key'])
+
+    upload_csv_page = UploadCsvPage(driver)
+
+    email_notification_id = send_notification_via_csv(profile, upload_csv_page, 'email')
+    email_notification = get_notification_by_id_via_api(
+        client,
+        email_notification_id,
+        ['sending', 'delivered']
+    )
+    assert_notification_body(email_notification_id, email_notification)
+
+    sms_notification_id = send_notification_via_csv(profile, upload_csv_page, 'sms')
+    sms_notification = get_notification_by_id_via_api(
+        client,
+        sms_notification_id,
+        ['sending', 'delivered']
+    )
+    assert_notification_body(sms_notification_id, sms_notification)
+
     do_edit_and_delete_email_template(driver, profile)
-
-    do_test_python_client_test_api_key(driver, profile, test_ids)
-
-    do_test_python_client_sms(profile, test_ids)
-    do_test_python_client_email(profile, test_ids)
-
-    # must be last, as it signs out the user
     do_user_can_invite_someone_to_notify(driver, profile)
-
-
-def do_user_registration(driver, base_url, profile):
-
-    main_page = MainPage(driver)
-    main_page.get()
-    main_page.click_set_up_account()
-
-    registration_page = RegistrationPage(driver)
-    assert registration_page.is_current()
-
-    registration_page.register(profile)
-
-    assert driver.current_url == base_url + '/registration-continue'
-
-    registration_link = get_link(profile, profile.registration_email_label,
-                                 profile.registration_template_id,
-                                 profile.email)
-
-    driver.get(registration_link)
-
-    do_verify(driver, profile)
-
-    add_service_page = AddServicePage(driver)
-    assert add_service_page.is_current()
-    add_service_page.add_service(profile.service_name)
-
-    dashboard_page = DashboardPage(driver)
-    service_id = dashboard_page.get_service_id()
-    dashboard_page.go_to_dashboard_for_service(service_id)
-
-    assert dashboard_page.h2_is_service_name(profile.service_name)
-
-
-def do_send_email_from_csv(driver, profile, test_ids):
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.click_email_templates()
-
-    send_email_page = SendEmailTemplatePage(driver)
-    send_email_page.click_upload_recipients()
-
-    directory, filename = create_temp_csv(profile.email, 'email address')
-
-    upload_csv_page = UploadCsvPage(driver)
-    upload_csv_page.upload_csv(directory, filename)
-    notification_id = upload_csv_page.get_notification_id_after_upload()
-
-    client = NotificationsAPIClient(Config.NOTIFY_API_URL,
-                                    test_ids['service_id'],
-                                    test_ids['api_key'])
-
-    notification = get_notification_by_id_via_api(client,
-                                                  notification_id,
-                                                  ['sending', 'delivered'])
-
-    assert_notification_body(notification_id, notification)
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-
-
-def do_send_sms_from_csv(driver, profile, test_ids):
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.click_sms_templates()
-
-    send_sms_page = SendSmsTemplatePage(driver)
-    send_sms_page.click_upload_recipients()
-
-    directory, filename = create_temp_csv(profile.mobile, 'phone number')
-
-    upload_csv_page = UploadCsvPage(driver)
-
-    upload_csv_page.upload_csv(directory, filename)
-
-    client = NotificationsAPIClient(Config.NOTIFY_API_URL,
-                                    test_ids['service_id'],
-                                    test_ids['api_key'])
-    notification_id = upload_csv_page.get_notification_id_after_upload()
-    notification = get_notification_by_id_via_api(client,
-                                                  notification_id,
-                                                  ['sending', 'delivered'])
-
-    assert_notification_body(notification_id, notification)
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-
-
-def do_edit_and_delete_email_template(driver, profile):
-    test_name = 'edit/delete test'
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-    dashboard_page.click_email_templates()
-
-    existing_templates = [x.text for x in driver.find_elements_by_class_name('message-name')]
-
-    all_templates_page = SendEmailTemplatePage(driver)
-    all_templates_page.click_add_new_template()
-
-    template_page = EditEmailTemplatePage(driver)
-    template_page.create_template(name=test_name)
-
-    assert test_name in [x.text for x in driver.find_elements_by_class_name('message-name')]
-
-    all_templates_page.click_edit_template()
-    template_page.click_delete()
-
-    assert [x.text for x in driver.find_elements_by_class_name('message-name')] == existing_templates
-
-
-def do_user_can_invite_someone_to_notify(driver, profile):
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.click_team_members_link()
-
-    team_members_page = TeamMembersPage(driver)
-    assert team_members_page.h1_is_team_members()
-    team_members_page.click_invite_user()
-
-    invite_user_page = InviteUserPage(driver)
-
-    invited_user_randomness = str(uuid.uuid1())
-    invited_user_name = 'Invited User ' + invited_user_randomness
-    invite_email = generate_unique_email(profile.email, invited_user_randomness)
-
-    invite_user_page.fill_invitation_form(invite_email, send_messages=True)
-    invite_user_page.send_invitation()
-
-    invite_link = get_link(profile, profile.invitation_email_label, profile.invitation_template_id, invite_email)
-
-    invite_user_page.sign_out()
-
-    # next part of interaction is from point of view of invitee
-    # i.e. after visting invite_link we'll be registering using invite_email
-    # but use same mobile number and password as profile
-
-    driver.get(invite_link)
-    register_from_invite_page = RegisterFromInvite(driver)
-    register_from_invite_page.fill_registration_form(invited_user_name, profile)
-    register_from_invite_page.click_continue()
-
-    do_verify(driver, profile)
-
-    dashboard_page = DashboardPage(driver)
-    service_id = dashboard_page.get_service_id()
-    dashboard_page.go_to_dashboard_for_service(service_id)
-
-    assert dashboard_page.h2_is_service_name(profile.service_name)
-
-    dashboard_page.sign_out()
-
-
-def do_test_python_client_sms(profile, test_ids):
-
-    client = NotificationsAPIClient(Config.NOTIFY_API_URL,
-                                    test_ids['service_id'],
-                                    test_ids['api_key'])
-
-    notification_id = send_notification_via_api(client, test_ids['sms_template_id'], profile.mobile, 'sms')
-    notification = get_notification_by_id_via_api(client, notification_id, ['sending', 'delivered'])
-    assert_notification_body(notification_id, notification)
-
-
-def do_test_python_client_email(profile, test_ids):
-
-    remove_all_emails(email_folder=profile.email_notification_label)
-
-    client = NotificationsAPIClient(Config.NOTIFY_API_URL,
-                                    test_ids['service_id'],
-                                    test_ids['api_key'])
-
-    notification_id = send_notification_via_api(client, test_ids['email_template_id'], profile.email, 'email')
-    notification = get_notification_by_id_via_api(client, notification_id, ['sending', 'delivered'])
-    assert_notification_body(notification_id, notification)
-
-    remove_all_emails(email_folder=profile.email_notification_label)
-
-
-def do_test_python_client_test_api_key(driver, profile, test_ids):
-    test_key = create_api_key(driver, 'test')
-
-    remove_all_emails(email_folder=profile.email_notification_label)
-
-    client = NotificationsAPIClient(Config.NOTIFY_API_URL, test_ids['service_id'], test_key)
-
-    notification_id = send_notification_via_api(client, test_ids['email_template_id'], profile.email, 'email')
-    notification = get_notification_by_id_via_api(client, notification_id, ['sending', 'delivered'])
-    assert_notification_body(notification_id, notification)
-
-    remove_all_emails(email_folder=profile.email_notification_label)
-
-
-def create_api_key(driver, key_type):
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-    dashboard_page.click_api_keys_link()
-
-    api_key_page = ApiKeyPage(driver)
-    api_key_page.click_keys_link()
-    api_key_page.click_create_key()
-
-    api_key_page.click_key_type_radio(key_type)
-    api_key_page.enter_key_name(key_type)
-    api_key_page.click_continue()
-    return api_key_page.get_api_key()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,12 +3,24 @@ import email as email_lib
 import imaplib
 import re
 import pytest
+import uuid
 
 from retry import retry
 from notifications_python_client.notifications import NotificationsAPIClient
 from config import Config
 
-from tests.pages import VerifyPage
+from tests.pages import (
+    MainPage,
+    RegistrationPage,
+    DashboardPage,
+    AddServicePage,
+    TeamMembersPage,
+    InviteUserPage,
+    RegisterFromInvite,
+    SendEmailTemplatePage,
+    EditEmailTemplatePage,
+    VerifyPage
+)
 
 
 def remove_all_emails(email=None, pwd=None, email_folder=None):
@@ -118,13 +130,108 @@ def get_link(profile, email_label, template_id, email):
         remove_all_emails(email_folder=email_label)
 
 
-@retry(RetryException, tries=15, delay=Config.EMAIL_DELAY)
+@retry(RetryException, tries=15, delay=Config.RETRY_DELAY)
 def do_verify(driver, profile):
     verify_code = get_verify_code_from_api(profile)
     verify_page = VerifyPage(driver)
     verify_page.verify(verify_code)
     if verify_page.has_code_error():
         raise RetryException
+
+
+def do_user_registration(driver, profile, base_url):
+
+    main_page = MainPage(driver)
+    main_page.get()
+    main_page.click_set_up_account()
+
+    registration_page = RegistrationPage(driver)
+    assert registration_page.is_current()
+
+    registration_page.register(profile)
+
+    assert driver.current_url == base_url + '/registration-continue'
+
+    registration_link = get_link(profile, profile.registration_email_label,
+                                 profile.registration_template_id,
+                                 profile.email)
+
+    driver.get(registration_link)
+
+    do_verify(driver, profile)
+
+    add_service_page = AddServicePage(driver)
+    assert add_service_page.is_current()
+    add_service_page.add_service(profile.service_name)
+
+    dashboard_page = DashboardPage(driver)
+    service_id = dashboard_page.get_service_id()
+    dashboard_page.go_to_dashboard_for_service(service_id)
+
+    assert dashboard_page.h2_is_service_name(profile.service_name)
+
+
+def do_user_can_invite_someone_to_notify(driver, profile):
+
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.click_team_members_link()
+
+    team_members_page = TeamMembersPage(driver)
+    assert team_members_page.h1_is_team_members()
+    team_members_page.click_invite_user()
+
+    invite_user_page = InviteUserPage(driver)
+
+    invited_user_randomness = str(uuid.uuid1())
+    invited_user_name = 'Invited User ' + invited_user_randomness
+    invite_email = generate_unique_email(profile.email, invited_user_randomness)
+
+    invite_user_page.fill_invitation_form(invite_email, send_messages=True)
+    invite_user_page.send_invitation()
+
+    invite_link = get_link(profile, profile.invitation_email_label, profile.invitation_template_id, invite_email)
+
+    invite_user_page.sign_out()
+
+    # next part of interaction is from point of view of invitee
+    # i.e. after visting invite_link we'll be registering using invite_email
+    # but use same mobile number and password as profile
+
+    driver.get(invite_link)
+    register_from_invite_page = RegisterFromInvite(driver)
+    register_from_invite_page.fill_registration_form(invited_user_name, profile)
+    register_from_invite_page.click_continue()
+
+    do_verify(driver, profile)
+    dashboard_page = DashboardPage(driver)
+    service_id = dashboard_page.get_service_id()
+    dashboard_page.go_to_dashboard_for_service(service_id)
+
+    assert dashboard_page.h2_is_service_name(profile.service_name)
+
+    dashboard_page.sign_out()
+
+
+def do_edit_and_delete_email_template(driver, profile):
+    test_name = 'edit/delete test'
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service()
+    dashboard_page.click_email_templates()
+
+    existing_templates = [x.text for x in driver.find_elements_by_class_name('message-name')]
+
+    all_templates_page = SendEmailTemplatePage(driver)
+    all_templates_page.click_add_new_template()
+
+    template_page = EditEmailTemplatePage(driver)
+    template_page.create_template(name=test_name)
+
+    assert test_name in [x.text for x in driver.find_elements_by_class_name('message-name')]
+
+    all_templates_page.click_edit_template()
+    template_page.click_delete()
+
+    assert [x.text for x in driver.find_elements_by_class_name('message-name')] == existing_templates
 
 
 def get_verify_code_from_api(profile):
@@ -136,7 +243,7 @@ def get_verify_code_from_api(profile):
     return m.group(0)
 
 
-@retry(RetryException, tries=15, delay=Config.EMAIL_DELAY)
+@retry(RetryException, tries=15, delay=Config.RETRY_DELAY)
 def get_notification_via_api(service_id, template_id, env, api_key, sent_to):
     client = NotificationsAPIClient(Config.NOTIFY_API_URL,
                                     service_id,


### PR DESCRIPTION
The following changes have been made:

1. A separate set of tests will run for preview:
    - Register a user, login, invite a user, verify they complete invitation flow
    - Send csv notifications (email & sms) with a research mode service and seeded user

2. The tests that run locally will remain the same, insofar as they will still test everything in 1. but without a research mode service. This is to avoid the pain of performing additional steps to run the functional tests locally 

3. The csv notification tests now include dashboard checks to verify counts are accurate and status is valid

4. General refactoring:
    - Separate retry delay variable
    - Sign out involves actually clicking the sign out link as opposed to a get request to /sign-out
    - Methods moved to utils as they will be shared 

5. For this to run on preview, additional config variables are required in the environment. These changes need to be applied for the tests can execute