### PR TITLE
Make API key locator work for old + new key format

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -77,7 +77,7 @@ class ApiKeysPageLocators(object):
     KEY_NAME_INPUT = (By.NAME, 'key_name')
     KEYS_PAGE_LINK = (By.LINK_TEXT, 'API keys')
     CREATE_KEY_LINK = (By.LINK_TEXT, 'Create an API key')
-    API_KEY_ELEMENT = (By.CLASS_NAME, 'api-key-key')
+    API_KEY_ELEMENT = (By.XPATH, "(//span[@class='api-key-key'])[last()]")
     NORMAL_KEY_RADIO = (By.XPATH, "//input[@value='normal']")
     TEST_KEY_RADIO = (By.XPATH, "//input[@value='test']")
     TEAM_KEY_RADIO = (By.XPATH, "//input[@value='team']")


### PR DESCRIPTION
The API keys page will show:

- new format

Then
- service ID
- API key (old format)

So the thing that the functional tests needs will always be the last one on the page.

This should mean we can merge https://github.com/alphagov/notifications-admin/pull/968 without breaking anything.