### PR TITLE
take screenshots on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ environment.sh
 /cache
 /venv
 docker.env
+
+screenshots

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ gunicorn==19.5.0
 requests==2.11.1
 beautifulsoup4>=4.5.1
 pep8==1.7.0
-pytest==2.8.3
+pytest==3.0.1
 retry==0.9.2
 selenium==2.53.1
 

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -45,7 +45,11 @@ function display_status {
 
 
 # remove any previous screenshots
-rm -v ./screenshots/*
+if [ -d screenshots ]; then
+  echo 'Removing old test screenshots'
+  rm -rfv screenshots
+fi
+mkdir screenshots
 
 case $ENVIRONMENT in
     staging|live)

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -43,6 +43,10 @@ function display_status {
   echo
 }
 
+
+# remove any previous screenshots
+rm -v ./screenshots/*
+
 case $ENVIRONMENT in
     staging|live)
       echo Running $ENVIRONMENT tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import uuid
 import pytest
+from datetime import datetime
+from pathlib import Path
 
 from selenium import webdriver
 
@@ -124,7 +126,7 @@ def profile():
 
 
 @pytest.fixture(scope="module")
-def driver(request):
+def _driver():
     driver_name = os.getenv('SELENIUM_DRIVER', 'chrome').lower()
     if os.environ.get('TRAVIS'):
         driver_name = 'firefox'
@@ -140,14 +142,23 @@ def driver(request):
     else:
         raise ValueError('Invalid Selenium driver', driver_name)
 
+    yield driver
+
     driver.delete_all_cookies()
+    driver.close()
 
-    def clear_up():
-        driver.delete_all_cookies()
-        driver.close()
 
-    request.addfinalizer(clear_up)
-    return driver
+@pytest.fixture(scope='function')
+def driver(_driver, request):
+    prev_failed_tests = request.session.testsfailed
+    yield _driver
+
+    if prev_failed_tests != request.session.testsfailed:
+        screenshots_folder = Path.cwd() / 'screenshots'
+        screenshots_folder.mkdir(exist_ok=True)
+        filename = str(screenshots_folder / '{}_{}.png'.format(datetime.utcnow(), request.function.__name__))
+        _driver.save_screenshot(str(filename))
+        print('Error screenshot saved to ' + filename)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,8 +142,8 @@ def _driver():
     else:
         raise ValueError('Invalid Selenium driver', driver_name)
 
+    driver.delete_all_cookies()
     yield driver
-
     driver.delete_all_cookies()
     driver.close()
 
@@ -152,11 +152,8 @@ def _driver():
 def driver(_driver, request):
     prev_failed_tests = request.session.testsfailed
     yield _driver
-
     if prev_failed_tests != request.session.testsfailed:
-        screenshots_folder = Path.cwd() / 'screenshots'
-        screenshots_folder.mkdir(exist_ok=True)
-        filename = str(screenshots_folder / '{}_{}.png'.format(datetime.utcnow(), request.function.__name__))
+        filename = str(Path.cwd() / 'screenshots' / '{}_{}.png'.format(datetime.utcnow(), request.function.__name__))
         _driver.save_screenshot(str(filename))
         print('Error screenshot saved to ' + filename)
 


### PR DESCRIPTION
* screenshots are taken every time a test fails
* they're saved to `./screenshots/{TIMESTAMP}_{TEST_NAME}.png`
* they're pretty neat
* pytest has been bumped to version 3 to allow for yielding fixtures