### PR TITLE
Provider test increase retry time

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,8 @@ class Config(object):
     EMAIL_TRIES = 36
     EMAIL_DELAY = 5
     RETRY_DELAY = 5
+    PROVIDER_RETRY_TIMES = 12
+    PROVIDER_RETRY_INTERVAL = 20
     FUNCTIONAL_TEST_SERVICE_NAME = os.environ['ENVIRONMENT'] + '_Functional Test Service_'
     NOTIFY_SERVICE_ID = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_ID']
     NOTIFY_SERVICE_API_KEY = os.environ[os.environ['ENVIRONMENT'] + '_NOTIFY_SERVICE_API_KEY']

--- a/tests/provider_delivery/test_provider_delivery_email.py
+++ b/tests/provider_delivery/test_provider_delivery_email.py
@@ -1,4 +1,5 @@
 from retry.api import retry_call
+from config import Config
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api
@@ -12,7 +13,7 @@ def test_send_sms_and_email_via_api(driver, profile, client):
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, 'delivered'],
-        tries=12,
-        jitter=20
+        tries=Config.PROVIDER_RETRY_TIMES,
+        jitter=Config.PROVIDER_RETRY_INTERVAL
     )
     assert_notification_body(notification_id, notification)

--- a/tests/provider_delivery/test_provider_delivery_email.py
+++ b/tests/provider_delivery/test_provider_delivery_email.py
@@ -1,3 +1,4 @@
+from retry.api import retry_call
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api
@@ -8,5 +9,10 @@ from tests.utils import assert_notification_body
 
 def test_send_sms_and_email_via_api(driver, profile, client):
     notification_id = send_notification_via_api(client, profile.email_template_id, profile.email, 'email')
-    notification = get_notification_by_id_via_api(client, notification_id, ['delivered'])
+    notification = retry_call(
+        get_notification_by_id_via_api,
+        fargs=[client, notification_id, 'delivered'],
+        tries=12,
+        jitter=20
+    )
     assert_notification_body(notification_id, notification)

--- a/tests/provider_delivery/test_provider_delivery_sms.py
+++ b/tests/provider_delivery/test_provider_delivery_sms.py
@@ -1,4 +1,5 @@
 from retry.api import retry_call
+from config import Config
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api
@@ -12,7 +13,7 @@ def test_send_sms_and_email_via_api(driver, profile, client):
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, 'delivered'],
-        tries=12,
-        jitter=20
+        tries=Config.PROVIDER_RETRY_TIMES,
+        jitter=Config.PROVIDER_RETRY_INTERVAL
     )
     assert_notification_body(notification_id, notification)

--- a/tests/provider_delivery/test_provider_delivery_sms.py
+++ b/tests/provider_delivery/test_provider_delivery_sms.py
@@ -1,3 +1,4 @@
+from retry.api import retry_call
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api
@@ -8,5 +9,10 @@ from tests.utils import assert_notification_body
 
 def test_send_sms_and_email_via_api(driver, profile, client):
     notification_id = send_notification_via_api(client, profile.sms_template_id, profile.mobile, 'sms')
-    notification = get_notification_by_id_via_api(client, notification_id, ['delivered'])
+    notification = retry_call(
+        get_notification_by_id_via_api,
+        fargs=[client, notification_id, 'delivered'],
+        tries=12,
+        jitter=20
+    )
     assert_notification_body(notification_id, notification)


### PR DESCRIPTION
Previously we were running provider-delivery checks every 5 seconds for a total of 75 seconds.

We want to give more leniency (driven by graphs on dashboard) to check every 20 seconds or so for up-to **4 minutes**. 