### PR TITLE
Add rigour to signout

### DIFF
--- a/tests/admin/test_admin_with_seeded_user.py
+++ b/tests/admin/test_admin_with_seeded_user.py
@@ -21,7 +21,7 @@ from tests.pages import (
 
 def test_registration_and_invite_flow(driver, profile, base_url):
     do_user_registration(driver, profile, base_url)
-    do_user_can_invite_someone_to_notify(driver, profile)
+    do_user_can_invite_someone_to_notify(driver, profile, base_url)
 
 
 @pytest.mark.parametrize('message_type', ['sms', 'email'])

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -59,6 +60,16 @@ class BasePage(object):
     def sign_out(self):
         element = self.wait_for_element(BasePage.sign_out_link)
         element.click()
+
+    def wait_until_url_is(self, url):
+        return WebDriverWait(self.driver, 10).until(
+            self.url_contains(url)
+        )
+
+    def url_contains(self, url):
+        def check_contains_url(driver):
+            return url in self.driver.current_url
+        return check_contains_url
 
 
 class MainPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait

--- a/tests/test_all_the_things.py
+++ b/tests/test_all_the_things.py
@@ -51,4 +51,4 @@ def test_everything(driver, profile, base_url, base_api_url):
     assert_notification_body(sms_notification_id, sms_notification)
 
     do_edit_and_delete_email_template(driver, profile)
-    do_user_can_invite_someone_to_notify(driver, profile)
+    do_user_can_invite_someone_to_notify(driver, profile, base_url)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,7 +171,7 @@ def do_user_registration(driver, profile, base_url):
     assert dashboard_page.h2_is_service_name(profile.service_name)
 
 
-def do_user_can_invite_someone_to_notify(driver, profile):
+def do_user_can_invite_someone_to_notify(driver, profile, base_url):
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.click_team_members_link()
@@ -188,15 +188,14 @@ def do_user_can_invite_someone_to_notify(driver, profile):
 
     invite_user_page.fill_invitation_form(invite_email, send_messages=True)
     invite_user_page.send_invitation()
-
-    invite_link = get_link(profile, profile.invitation_email_label, profile.invitation_template_id, invite_email)
-
     invite_user_page.sign_out()
+    invite_user_page.wait_until_url_is(base_url)
 
     # next part of interaction is from point of view of invitee
     # i.e. after visting invite_link we'll be registering using invite_email
     # but use same mobile number and password as profile
 
+    invite_link = get_link(profile, profile.invitation_email_label, profile.invitation_template_id, invite_email)
     driver.get(invite_link)
     register_from_invite_page = RegisterFromInvite(driver)
     register_from_invite_page.fill_registration_form(invited_user_name, profile)
@@ -243,7 +242,7 @@ def get_verify_code_from_api(profile):
     return m.group(0)
 
 
-@retry(RetryException, tries=15, delay=Config.RETRY_DELAY)
+@retry(RetryException, tries=2, delay=1)
 def get_notification_via_api(service_id, template_id, env, api_key, sent_to):
     client = NotificationsAPIClient(Config.NOTIFY_API_URL,
                                     service_id,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -242,7 +242,7 @@ def get_verify_code_from_api(profile):
     return m.group(0)
 
 
-@retry(RetryException, tries=2, delay=1)
+@retry(RetryException, tries=15, delay=Config.RETRY_DELAY)
 def get_notification_via_api(service_id, template_id, env, api_key, sent_to):
     client = NotificationsAPIClient(Config.NOTIFY_API_URL,
                                     service_id,


### PR DESCRIPTION
Add a wait function that can be used to check we are on the right page
Sign-out the user before calling API for invite link
Use wait function to ensure user is signed out before invite link is clicked
