### PR TITLE
Increase retry time for job to 50 sec

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -349,7 +349,7 @@ class UploadCsvPage(BasePage):
         self.click_send()
         shutil.rmtree(directory, ignore_errors=True)
 
-    @retry(RetryException, tries=5, delay=4)
+    @retry(RetryException, tries=5, delay=10)
     def get_notification_id_after_upload(self):
         try:
             element = self.wait_for_element(UploadCsvPage.first_notification)


### PR DESCRIPTION
This change increases the time we wait for a notification id to appear on the page after a csv upload is triggered. This will workaround the issue where time between processing a job and sending sms is delayed due to how SQS 'short-polls':

http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/DistributedQueues.html
