### PR TITLE
reduced provider test retry timeout

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,8 +12,8 @@ class Config(object):
     EMAIL_TRIES = 36
     EMAIL_DELAY = 5
     RETRY_DELAY = 5
-    PROVIDER_RETRY_TIMES = 12
-    PROVIDER_RETRY_INTERVAL = 20
+    PROVIDER_RETRY_TIMES = 3
+    PROVIDER_RETRY_INTERVAL = 0
     FUNCTIONAL_TEST_SERVICE_NAME = os.environ.get('ENVIRONMENT') + '_Functional Test Service_'
     NOTIFY_SERVICE_ID = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_SERVICE_ID')
     NOTIFY_SERVICE_API_KEY = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_SERVICE_API_KEY')


### PR DESCRIPTION
because the provider test calls a function that itself retries for up to 75 seconds (plus execution time), we don't it need to repeat 12 times - that'll lead to 30min+ runtimes. so just retry 3 times, for a grand total time of 4 minutes maximum. it'll only get that long if our provider isn't giving delivery receipts!