### PR TITLE
Add wait to make sure element is visible

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -53,6 +53,7 @@ class BasePage(object):
 
     def wait_for_element(self, locator):
         return WebDriverWait(self.driver, 10).until(
+            EC.visibility_of_element_located(locator),
             EC.presence_of_element_located(locator)
         )
 


### PR DESCRIPTION
Seems like we have to explicitly wait for an element to be visible before we can wait for it to be present. 