### PR TITLE
Make sure invited user is properly signed out before next test runs

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,6 +144,8 @@ def do_user_can_invite_someone_to_notify(driver, profile, base_url):
 
     dashboard_page.sign_out()
     dashboard_page.wait_until_url_is(base_url)
+    # Clear user cookies before next test executes
+    driver.delete_all_cookies()
 
 
 def do_edit_and_delete_email_template(driver):


### PR DESCRIPTION
We noticed errors occurring where the invited user was still signed in for the upload CSV related tests. The latter tests are meant to sign in with a seeded user, but were signing in with the invited user. This is because once we signed out the invited user account (do_user_can_invite_someone_to_notify) we did not clear the cookies. 