### PR TITLE
Retry on stale element exception

### DIFF
--- a/tests/admin/test_admin_with_seeded_user.py
+++ b/tests/admin/test_admin_with_seeded_user.py
@@ -4,10 +4,11 @@ from retry.api import retry_call
 from config import Config
 from selenium.common.exceptions import TimeoutException
 
+from tests.decorators import retry_on_stale_element_exception
+
 from tests.postman import (
     send_notification_via_csv,
     get_notification_by_id_via_api)
-
 
 from tests.utils import (
     do_user_registration,
@@ -54,6 +55,7 @@ def test_send_csv(driver, profile, login_seeded_user, seeded_client, message_typ
     assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after)
 
 
+@retry_on_stale_element_exception
 def get_dashboard_stats(dashboard_page, message_type, template_id):
     return {
         'total_messages_sent': dashboard_page.get_total_message_count(message_type),

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,0 +1,12 @@
+from selenium.common.exceptions import TimeoutException, StaleElementReferenceException
+
+
+def retry_on_stale_element_exception(func):
+    def wrapped(*args, **kwargs):
+        try:
+            result = func(*args, **kwargs)
+        except StaleElementReferenceException:
+            result = func(*args, **kwargs)
+        return result
+
+    return wrapped

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,12 +1,17 @@
-from selenium.common.exceptions import TimeoutException, StaleElementReferenceException
+from selenium.common.exceptions import StaleElementReferenceException
 
 
 def retry_on_stale_element_exception(func):
     def wrapped(*args, **kwargs):
-        try:
-            result = func(*args, **kwargs)
-        except StaleElementReferenceException:
-            result = func(*args, **kwargs)
-        return result
+        retry = 5
+        while retry:
+            try:
+                result = func(*args, **kwargs)
+            except StaleElementReferenceException as e:
+                if retry:
+                    retry -= 1
+                    continue
+                raise e
+            return result
 
     return wrapped


### PR DESCRIPTION
A StaleElementReferenceException occurs on some occasions when we try to retrieve stats on the dashboard. This is because the page refreshes every two seconds which can cause elements to become stale. In this case, on such an exception, we will try getting the stats again using a decorator function.