### PR TITLE
Fix issue causing exception on verification

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,8 +79,7 @@ def do_verify(driver, profile):
             except (NoSuchElementException, TimeoutException) as e:
                 #  In some cases a TimeoutException is raised even if we have managed to verify.
                 #  For now, check explicitly if we 'have verified' and if so move on.
-                if 'two-factor' not in driver.current_url:
-                    return True
+                return True
             else:
                 #  There was an error message so let's retry
                 return False


### PR DESCRIPTION
This fixes an issue where our functional tests fails during 2fa, despite having verified successfully.

During the 2fa stage, a `TimeoutException` is raised occasionally due to verification _apparently_ not being completed. However after checking we can see verification succeeded. Until we can dig deep to find the real issue, this adds a explicit check to see if we verified and proceed on with the test if so.