### PR TITLE
Add build id into docker env

### DIFF
--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -40,3 +40,5 @@ env_vars=(
 for env_var in "${env_vars[@]}"; do
     echo "${ENVIRONMENT}_${env_var}=${!env_var}" >> docker.env
 done
+
+echo "BUILD_ID=$BUILD_ID" >> docker.env


### PR DESCRIPTION
This fixes the issue where the Jenkins build id is not shown in our emails/sms. This is because the build id was missing from the docker env and needs to be added explicitly.