### PR TITLE
Add more details to notification timeout exception

### DIFF
--- a/tests/postman.py
+++ b/tests/postman.py
@@ -39,7 +39,16 @@ def get_notification_by_id_via_api(client, notification_id, expected_statuses):
         resp = client.get_notification_by_id(notification_id)
         notification_status = resp['data']['notification']['status']
         if notification_status not in expected_statuses:
-            raise RetryException('Notification still in {}'.format(notification_status))
+            raise RetryException(
+                (
+                    'Notification in wrong status '
+                    'id: {id} '
+                    'status: {status} '
+                    'created_at: {created_at} '
+                    'sent_at: {sent_at} '
+                    'updated_at: {updated_at}'
+                ).format(**resp['data']['notification'])
+            )
         return resp["data"]["notification"]
     except HTTPError as e:
         if e.status_code == 404:


### PR DESCRIPTION
Currently we just see error messages like `tests.test_utils.RetryException: Notification still in sending`

with this we can get a bit more context. Note, we are still using the v1 api (!) so when we upgrade functional tests the field names may need to change