### PR TITLE
Add flake8 linting to project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# W503: line break before binary operator
+exclude = venv*,__pycache__,cache
+ignore = W503
+max-complexity = 8
+max-line-length = 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Cache==0.13.1
 gunicorn==19.7.1
 requests==2.18.4
 beautifulsoup4>=4.5.1
-pep8==1.7.0
+flake8==3.5.0
 pytest==3.2.3
 retry==0.9.2
 selenium==3.6.0

--- a/tests/pages/__init__.py
+++ b/tests/pages/__init__.py
@@ -1,1 +1,1 @@
-from .pages import *
+from .pages import *  # noqa

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -17,7 +17,6 @@ from tests.pages.element import (
     NameInputElement,
     MobileInputElement,
     ServiceInputElement,
-    ServiceOrgTypeElement,
     TemplateContentElement,
     FileInputElement,
     SubjectInputElement,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from retry import retry
 from notifications_python_client.notifications import NotificationsAPIClient
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
-from selenium.webdriver.support.ui import WebDriverWait
 
 from config import Config
 from tests.pages import (


### PR DESCRIPTION
The GDS Way™[1] recommends using Flake8 to lint Python projects.

This commit takes the Flake8 config from Digital Marketplace API[2] and removes the bits we don’t need.

It changes the `max_complexity` setting to 8, which is the most complex code we have in this repo currently (we shouldn’t be writing code _more_ complex than what we already have).

This commit also fixes the errors found by Flake8:
```
./tests/test_utils.py:14:1: F401 'selenium.webdriver.support.ui.WebDriverWait' imported but unused
./tests/pages/__init__.py:1:1: F403 'from .pages import *' used; unable to detect undefined names
./tests/pages/__init__.py:1:1: F401 '.pages.*' imported but unused
./tests/pages/pages.py:13:1: F401 'tests.pages.element.ServiceOrgTypeElement' imported but unused
```

1. https://gds-way.cloudapps.digital/manuals/programming-languages/python/linting.html#how-to-use-flake8
2. https://github.com/alphagov/digitalmarketplace-api/blob/d5ab8afef4a0472f9d266d94ab4ffe1333a9aaad/.flake8

***

Closes #93