### PR TITLE
Update noti python client to 4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest==3.2.3
 retry==0.9.2
 selenium==3.6.0
 
-git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
+git+https://github.com/alphagov/notifications-python-client.git@4.5.0#egg=notifications-python-client==4.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,6 @@ def login_seeded_user(_driver, profile):
 def client(profile):
     client = NotificationsAPIClient(
         base_url=profile.notify_api_url,
-        service_id=profile.service_id,
         api_key=profile.api_key
     )
     return client
@@ -218,7 +217,6 @@ def client(profile):
 def seeded_client(profile):
     client = NotificationsAPIClient(
         base_url=profile.notify_api_url,
-        service_id=profile.notify_research_service_id,
         api_key=profile.notify_research_service_api_key
     )
     return client

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -13,7 +13,7 @@ def send_notification_via_api(client, template_id, to, message_type):
     elif message_type == 'email':
         resp_json = client.send_email_notification(to, template_id, personalisation)
 
-    return resp_json['data']['notification']['id']
+    return resp_json['id']
 
 
 def send_notification_via_csv(profile, upload_csv_page, message_type, seeded=False):
@@ -37,7 +37,7 @@ def send_notification_via_csv(profile, upload_csv_page, message_type, seeded=Fal
 def get_notification_by_id_via_api(client, notification_id, expected_statuses):
     try:
         resp = client.get_notification_by_id(notification_id)
-        notification_status = resp['data']['notification']['status']
+        notification_status = resp['status']
         if notification_status not in expected_statuses:
             raise RetryException(
                 (
@@ -46,10 +46,10 @@ def get_notification_by_id_via_api(client, notification_id, expected_statuses):
                     'status: {status} '
                     'created_at: {created_at} '
                     'sent_at: {sent_at} '
-                    'updated_at: {updated_at}'
-                ).format(**resp['data']['notification'])
+                    'completed_at: {completed_at}'
+                ).format(**resp)
             )
-        return resp["data"]["notification"]
+        return resp
     except HTTPError as e:
         if e.status_code == 404:
             message = 'Notification not created yet for id: {}'.format(notification_id)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,7 +201,6 @@ def get_verify_code_from_api(profile):
 def get_notification_via_api(service_id, template_id, api_key, sent_to):
     client = NotificationsAPIClient(
         base_url=Config.NOTIFY_API_URL,
-        service_id=service_id,
         api_key=api_key
     )
     resp = client.get('notifications', params={'include_jobs': True})


### PR DESCRIPTION
Will need to also update the API keys in each environment as current API keys do not have the service id as part of the key and the latest python client does not accept `service_id` as an argument

- [x] - preview API keys updated
- [x] - staging API keys updated
- [x] - live API keys updated