### PR TITLE
Lock phantomjs-prebuilt to 2.1.15

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN \
 		nodejs \
 		npm \
 	&& ln -s /usr/bin/nodejs /usr/bin/node \
-	&& npm -g install phantomjs-prebuilt
+	&& npm -g install phantomjs-prebuilt@2.1.15
 
 ADD mozilla.gpg /tmp/mozilla.gpg
 RUN \


### PR DESCRIPTION
The update to phantomjs-prebuilt 2.1.16 pulls in a new version of the request npm module that no longer supports node 0.10.

To fix this temporarily, install phantomjs-prebuilt@2.1.15.