### PR TITLE
functional tests now have two preset status sets to check against

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -8,7 +8,8 @@ from tests.decorators import retry_on_stale_element_exception
 
 from tests.postman import (
     send_notification_via_csv,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import (
@@ -42,7 +43,7 @@ def test_send_csv(driver, profile, login_seeded_user, seeded_client, message_typ
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[seeded_client, notification_id, ['sending', 'delivered']],
+        fargs=[seeded_client, notification_id, NotificationStatuses.SENT],
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
@@ -3,7 +3,8 @@ from config import Config
 
 from tests.postman import (
     send_notification_via_api,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import assert_notification_body, recordtime
@@ -18,7 +19,7 @@ def test_send_email_notification_via_api(profile, client):
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, ['sending', 'delivered']],
+        fargs=[client, notification_id, NotificationStatuses.SENT],
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
@@ -3,7 +3,8 @@ from config import Config
 
 from tests.postman import (
     send_notification_via_api,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import assert_notification_body, recordtime
@@ -18,7 +19,7 @@ def test_send_sms_notification_via_api(profile, client):
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, ['sending', 'delivered']],
+        fargs=[client, notification_id, NotificationStatuses.SENT],
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )

--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -5,7 +5,8 @@ from tests.pages import UploadCsvPage
 
 from tests.postman import (
     send_notification_via_csv,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import assert_notification_body, recordtime
@@ -17,7 +18,7 @@ def test_admin(driver, base_url, client, profile, login_user):
     csv_sms_notification_id = send_notification_via_csv(profile, upload_csv_page, 'sms')
     csv_sms_notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, csv_sms_notification_id, ['sending', 'delivered']],
+        fargs=[client, csv_sms_notification_id, NotificationStatuses.SENT],
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )
@@ -26,7 +27,7 @@ def test_admin(driver, base_url, client, profile, login_user):
     csv_email_notification_id = send_notification_via_csv(profile, upload_csv_page, 'email')
     csv_email_notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, csv_email_notification_id, ['sending', 'delivered']],
+        fargs=[client, csv_email_notification_id, NotificationStatuses.SENT],
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -34,6 +34,11 @@ def send_notification_via_csv(profile, upload_csv_page, message_type, seeded=Fal
     return notification_id
 
 
+class NotificationStatuses:
+    DELIVERED = {'delivered', 'temporary-failure', 'permanent-failure'}
+    SENT = DELIVERED | {'sending'}
+
+
 def get_notification_by_id_via_api(client, notification_id, expected_statuses):
     try:
         resp = client.get_notification_by_id(notification_id)

--- a/tests/provider_delivery/test_provider_delivery_email.py
+++ b/tests/provider_delivery/test_provider_delivery_email.py
@@ -2,7 +2,8 @@ from retry.api import retry_call
 from config import Config
 from tests.postman import (
     send_notification_via_api,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import assert_notification_body
@@ -15,7 +16,7 @@ def test_provider_email_delivery_via_api(profile, client):
     )
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, 'delivered'],
+        fargs=[client, notification_id, NotificationStatuses.DELIVERED],
         tries=Config.PROVIDER_RETRY_TIMES,
         delay=Config.PROVIDER_RETRY_INTERVAL
     )

--- a/tests/provider_delivery/test_provider_delivery_sms.py
+++ b/tests/provider_delivery/test_provider_delivery_sms.py
@@ -2,7 +2,8 @@ from retry.api import retry_call
 from config import Config
 from tests.postman import (
     send_notification_via_api,
-    get_notification_by_id_via_api
+    get_notification_by_id_via_api,
+    NotificationStatuses
 )
 
 from tests.test_utils import assert_notification_body
@@ -15,7 +16,7 @@ def test_provider_sms_delivery_via_api(profile, client):
     )
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, 'delivered'],
+        fargs=[client, notification_id, NotificationStatuses.DELIVERED],
         tries=Config.PROVIDER_RETRY_TIMES,
         delay=Config.PROVIDER_RETRY_INTERVAL
     )


### PR DESCRIPTION
You're encouraged to pass in `NotificationStatuses.SENT` or
`NotificationStatuses.DELIVERED`.

We've seen problems with our provider tests (which go to a twilio number) failing because of permanent failures.

If we get a delivery receipt, we know we got through to the providers - so lets just check for that rather than specifically expecting success