### PR TITLE
Remove previous dashboard URL

### DIFF
--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -8,8 +8,4 @@ def test_email_auth(driver, profile, base_url):
     # login email auth user
     sign_in_email_auth(driver, profile)
     # assert url is research mode service's dashboard
-    assert (
-        driver.current_url == base_url + '/services/{}/dashboard'.format(profile.notify_research_service_id)
-    ) or (
-        driver.current_url == base_url + '/services/{}'.format(profile.notify_research_service_id)
-    )
+    assert driver.current_url == base_url + '/services/{}'.format(profile.notify_research_service_id)


### PR DESCRIPTION
We’ve deployed the new one now, this PR just cleans up the functional test code.