### PR TITLE
Added extra assertions to the precompiled letter tests

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -28,7 +28,8 @@ from tests.pages import (
     DashboardPage,
     SendOneRecipient,
     SmsSenderPage,
-    UploadCsvPage)
+    UploadCsvPage,
+    PreviewLetterPage)
 
 
 @recordtime
@@ -182,6 +183,18 @@ def test_view_precompiled_letter_message_log_delivered(
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )
 
+    ref_link = "https://www.notify.works/services/" + \
+               profile.notify_research_service_id + \
+               "/notification/" + \
+               api_integration_page.get_notification_id()
+    link = api_integration_page.get_view_letter_link()
+    assert ref_link == link
+
+    api_integration_page.go_to_preview_letter()
+
+    letter_preview_page = PreviewLetterPage(driver)
+    assert letter_preview_page.is_text_present_on_page("Provided as PDF, sent on")
+
 
 def test_view_precompiled_letter_message_log_virus_scan_failed(
         driver,
@@ -206,6 +219,13 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(
         tries=Config.NOTIFICATION_RETRY_TIMES,
         delay=Config.NOTIFICATION_RETRY_INTERVAL
     )
+
+    ref_link = "https://www.notify.works/services/" + \
+               profile.notify_research_service_id + \
+               "/notification/" + \
+               api_integration_page.get_notification_id()
+    link = api_integration_page.get_view_letter_link()
+    assert ref_link != link
 
 
 def _check_status_of_notification(page, notify_research_service_id, reference_to_check, status_to_check):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -105,6 +105,7 @@ class ApiIntegrationPageLocators(object):
     MESSAGE_LOG = (By.CSS_SELECTOR, 'div.api-notifications > details:nth-child(1)')
     CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item-recipient')
     MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item-data-item')
+    VIEW_LETTER_LINK = (By.LINK_TEXT, 'View letter')
 
 
 class ApiKeysPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -515,6 +515,11 @@ class ApiIntegrationPage(BasePage):
     message_log = ApiIntegrationPageLocators.MESSAGE_LOG
     client_reference = ApiIntegrationPageLocators.CLIENT_REFERENCE
     message_list = ApiIntegrationPageLocators.MESSAGE_LIST
+    view_letter_link = ApiIntegrationPageLocators.VIEW_LETTER_LINK
+
+    def get_notification_id(self):
+        element = self.wait_for_elements(ApiIntegrationPage.message_list)[0]
+        return element.text
 
     def click_message_log(self):
         element = self.wait_for_element(ApiIntegrationPage.message_log)
@@ -531,6 +536,20 @@ class ApiIntegrationPage(BasePage):
     def get_status_from_message(self):
         element = self.wait_for_elements(ApiIntegrationPage.message_list)[5]
         return element.text
+
+    def get_view_letter_link(self):
+        link = self.wait_for_elements(ApiIntegrationPage.view_letter_link)[0]
+        return link.get_attribute("href")
+
+    def go_to_preview_letter(self):
+        link = self.wait_for_elements(ApiIntegrationPage.view_letter_link)[0]
+        self.driver.get(link.get_attribute("href"))
+
+
+class PreviewLetterPage(BasePage):
+
+    def is_text_present_on_page(self, search_text):
+        return search_text not in self.driver.page_source
 
 
 class ApiKeyPage(BasePage):


### PR DESCRIPTION
Added extra assertion to the precompiled letter tests to check that the link in the message log is enabled when the letter has been successfully virus scanned. If the link is present and matches the predicted link it checks that the page can be visited and that there is a precompiled
letter text on the page. Further checks to this page will be added in a new test navigated from the main admin page rather than the message log.

* Added extra check to existing delivered and failed tests
* Added extra method to the page utils class
* Created a new class for the preview letter page
* Added a new locator to find the link on the message log page