### PR TITLE
Separate env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ target/
 
 .DS_Store
 # environment variable file
-environment.sh
+environment*.sh
 
 /cache
 /venv

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-providers: venv ## Run tests
 	su -c '/var/project/scripts/run_test_script.sh /var/project/tests/provider_delivery/' hostuser
 
 .PHONY: test-document-download
-test-document-download: venv ## Run documnet-download-api tests
+test-document-download: venv ## Run document-download-api tests
 	su -c '/var/project/scripts/run_test_script.sh /var/project/tests/document_download/' hostuser
 
 .PHONY: generate-env-file
@@ -94,13 +94,12 @@ build-with-docker: prepare-docker-runner-image ## Build inside a Docker containe
 		make build
 
 define run_test_container
+	[ ${ENVIRONMENT} != "dev" ] # Cannot run in docker against development
 	make prepare-docker-runner-image generate-env-file
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-test" \
-		--add-host=api.local:192.168.65.1 \
 		-v "`pwd`:/var/project" \
 		-v /dev/urandom:/dev/random \
-		-e ENVIRONMENT=${ENVIRONMENT} \
 		-e UID=$(shell id -u) \
 		-e GID=$(shell id -g) \
 		-e SELENIUM_DRIVER=${SELENIUM_DRIVER} \

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export DOCUMENT_DOWNLOAD_API_KEY=auth-token # document-download-api auth token
   - Store its name in `NOTIFY_RESEARCH_SERVICE_NAME` and its id in `NOTIFY_RESEARCH_SERVICE_ID`
   - set it into research mode
   - grant it the email auth permission ("Allow editing user auth")
+  - grant it the precompiled letters permission ("Allow to send precompiled letters")
 * Create an organisation
   - Assign the research mode functional test service to this organisation
   - store the organisation's id in `NOTIFY_RESEARCH_ORGANISATION_ID`

--- a/README.md
+++ b/README.md
@@ -18,33 +18,32 @@ To run locally you need to populate a `.gitignore` and `environment.sh` file wit
 - Create a local `environment.sh` file in the root directory of the project.
 This file is included in the `.gitignore` to prevent the environment file from being accidentally committed
 - Make sure `Notifications Admin`, `Notifications Template Preview`, `Notifications API` and `Notifications API celery` are running locally.
+- To run against preview, staging, or live, grab the environment files found in credentials repo in `credentials/functional-tests/{env_name}`, and save them locally to a separate file that you can source separately. `environment_staging.sh`
 
 <details>
     <summary>Contents of the environment.sh file</summary>
 
 ```shell
 export ENVIRONMENT=dev  # for local environments use dev
-export dev_TEST_NUMBER= [use your own number]
-export dev_FUNCTIONAL_TEST_EMAIL= # the account to create new users for in test_registration
-export dev_FUNCTIONAL_TEST_PASSWORD=xxx # password for user account above (created automatically in test)
-export dev_NOTIFY_ADMIN_URL=http://localhost:6012
-export dev_NOTIFY_API_URL=http://localhost:6011
-export dev_NOTIFY_SERVICE_API_KEY=xxx  # create an api key for the GOV.UK Notify service via the admin app
-export dev_NOTIFY_RESEARCH_SERVICE_NAME=xxx # See seeded service section below for details of the seeded research service.
-export dev_NOTIFY_RESEARCH_SERVICE_ID=xxx # create a service in research mode via the admin app and copy the service id here
-export dev_NOTIFY_RESEARCH_SERVICE_API_KEY=xxx # create an api key for the Research service via the admin app
-export dev_NOTIFY_RESEARCH_SERVICE_API_TEST_KEY=xxx # create a test api key for the Research service via the admin app
-export dev_NOTIFY_RESEARCH_EMAIL_REPLY_TO=[a gov email] # this is the second email in the list when the you go to the send email to one recipient screen i.e. not the default but the second one added
-export dev_NOTIFY_RESEARCH_MODE_EMAIL= # a seeded account you have created that can only access NOTIFY_RESEARCH_SERVICE_ID
-export dev_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD=xxx # password for the above account
-export dev_NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT= # a seeded account you have created that can only access NOTIFY_RESEARCH_SERVICE_ID, doesn't need any permissions and must use email auth
-export dev_NOTIFY_RESEARCH_ORGANISATION_ID=xxx # id of organisation that seeded service belongs to
-export dev_JENKINS_BUILD_SMS_TEMPLATE_ID=xxx # SMS template id created in research service, contents detailed below
-export dev_JENKINS_BUILD_EMAIL_TEMPLATE_ID=xxx # Email template id created in research service, contents detailed below
-export dev_JENKINS_BUILD_LETTER_TEMPLATE_ID=xxx # Letter template id created in research service, contents detailed below
+export TEST_NUMBER= [use your own number or a TV block number like 07700900001]
+export FUNCTIONAL_TEST_EMAIL= # the account to create new users for in test_registration
+export FUNCTIONAL_TEST_PASSWORD=xxx # password for user account above (created automatically in test)
+export NOTIFY_SERVICE_API_KEY=xxx  # create an api key for the GOV.UK Notify service via the admin app
+export NOTIFY_RESEARCH_SERVICE_NAME=xxx # See seeded service section below for details of the seeded research service.
+export NOTIFY_RESEARCH_SERVICE_ID=xxx # create a service in research mode via the admin app and copy the service id here
+export NOTIFY_RESEARCH_SERVICE_API_KEY=xxx # create an api key for the Research service via the admin app
+export NOTIFY_RESEARCH_SERVICE_API_TEST_KEY=xxx # create a test api key for the Research service via the admin app
+export NOTIFY_RESEARCH_EMAIL_REPLY_TO=[a gov email] # this is the second email in the list when the you go to the send email to one recipient screen i.e. not the default but the second one added
+export NOTIFY_RESEARCH_MODE_EMAIL= # a seeded account you have created that can only access NOTIFY_RESEARCH_SERVICE_ID
+export NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD=xxx # password for the above account
+export NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT= # a seeded account you have created that can only access NOTIFY_RESEARCH_SERVICE_ID, doesn't need any permissions and must use email auth
+export NOTIFY_RESEARCH_ORGANISATION_ID=xxx # id of organisation that seeded service belongs to
+export JENKINS_BUILD_SMS_TEMPLATE_ID=xxx # SMS template id created in research service, contents detailed below
+export JENKINS_BUILD_EMAIL_TEMPLATE_ID=xxx # Email template id created in research service, contents detailed below
+export JENKINS_BUILD_LETTER_TEMPLATE_ID=xxx # Letter template id created in research service, contents detailed below
 
-export dev_DOCUMENT_DOWNLOAD_API_HOST=http://localhost:7000
-export dev_DOCUMENT_DOWNLOAD_API_KEY=auth-token # document-download-api auth token
+export DOCUMENT_DOWNLOAD_API_HOST=http://localhost:7000
+export DOCUMENT_DOWNLOAD_API_KEY=auth-token # document-download-api auth token
 
 ```
 </details>
@@ -53,28 +52,28 @@ export dev_DOCUMENT_DOWNLOAD_API_KEY=auth-token # document-download-api auth tok
     <summary>The seeded research mode service will need to be created as follows: </summary>
 
 * Create a service.
-  - Store its name in `dev_NOTIFY_RESEARCH_SERVICE_NAME` and its id in `dev_NOTIFY_RESEARCH_SERVICE_ID`
+  - Store its name in `NOTIFY_RESEARCH_SERVICE_NAME` and its id in `NOTIFY_RESEARCH_SERVICE_ID`
   - set it into research mode
   - grant it the email auth permission ("Allow editing user auth")
 * Create an organisation
   - Assign the research mode functional test service to this organisation
-  - store the organisation's id in `dev_NOTIFY_RESEARCH_ORGANISATION_ID`
-  - invite the seeded user (`dev_NOTIFY_RESEARCH_MODE_EMAIL`) to the organisation
-* create a test mode API key for it, store that in `dev_NOTIFY_RESEARCH_SERVICE_API_KEY`
-* Two email reply-to addresses will have to be added. One default email, the name of which doesn't matter, and a second non-default email, the name of which you should save in `dev_NOTIFY_RESEARCH_EMAIL_REPLY_TO`.
+  - store the organisation's id in `NOTIFY_RESEARCH_ORGANISATION_ID`
+  - invite the seeded user (`NOTIFY_RESEARCH_MODE_EMAIL`) to the organisation
+* create a test mode API key for it, store that in `NOTIFY_RESEARCH_SERVICE_API_KEY`
+* Two email reply-to addresses will have to be added. One default email, the name of which doesn't matter, and a second non-default email, the name of which you should save in `NOTIFY_RESEARCH_EMAIL_REPLY_TO`.
 * You will need two Text message senders, one that is the default and another that has a value of "func tests'.
 * A seeded user will have to be created and invited to it with the following details:
-  - email_address: `dev_NOTIFY_RESEARCH_MODE_EMAIL`
-  - phone_number: `dev_TEST_NUMBER`
-  - password: `dev_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD`
+  - email_address: `NOTIFY_RESEARCH_MODE_EMAIL`
+  - phone_number: `TEST_NUMBER`
+  - password: `NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD`
   - all permissions for the seeded service.
   - the user should also accept the invite from the seeded organisation
   - sms auth
 * A second seeded user will have to be invited with the following details
-  - email_address: `dev_NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT`, this can be set to `notify-tests-preview+email-auth@digital.cabinet-office.gov.uk` to send auth emails to a test email account.
+  - email_address: `NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT`, this can be set to `notify-tests-preview+email-auth@digital.cabinet-office.gov.uk` to send auth emails to a test email account.
   - no permissions required
   - email auth
-  - The password should be set the same as above - see `dev_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD`.
+  - The password should be set the same as above - see `NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD`.
 
 </details>
 
@@ -121,6 +120,8 @@ The app uses Selenium to run web automation tests which requires ChromeDriver. I
 Running the tests
 
 ```shell
+    source environment.sh
+    # source environment_preview.sh # etc etc
     ./scripts/run_functional_tests.sh
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,80 +1,140 @@
+import uuid
 import os
 
-
-class Config(object):
-    ENVIRONMENT = os.environ['ENVIRONMENT']
-    NOTIFY_ADMIN_URL = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_ADMIN_URL')
-    NOTIFY_API_URL = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_API_URL')
-    TEST_NUMBER = os.environ.get(os.environ.get('ENVIRONMENT') + '_TEST_NUMBER')
-    FUNCTIONAL_TEST_NAME = os.environ.get('ENVIRONMENT') + '_Functional Test_'
-    FUNCTIONAL_TEST_EMAIL = os.environ.get(os.environ.get('ENVIRONMENT') + '_FUNCTIONAL_TEST_EMAIL')
-    FUNCTIONAL_TEST_PASSWORD = os.environ.get(os.environ.get('ENVIRONMENT') + '_FUNCTIONAL_TEST_PASSWORD')
-    NOTIFICATION_RETRY_TIMES = 15
-    NOTIFICATION_RETRY_INTERVAL = 5
-    PROVIDER_RETRY_TIMES = 12
-    PROVIDER_RETRY_INTERVAL = 22
-    VERIFY_CODE_RETRY_TIMES = 8
-    VERIFY_CODE_RETRY_INTERVAL = 9
-    FUNCTIONAL_TEST_SERVICE_NAME = os.environ.get('ENVIRONMENT') + '_Functional Test Service_'
-    JENKINS_BUILD_SMS_TEMPLATE_ID = os.environ.get(os.environ.get('ENVIRONMENT') + '_JENKINS_BUILD_SMS_TEMPLATE_ID')
-    JENKINS_BUILD_EMAIL_TEMPLATE_ID = os.environ.get(os.environ.get('ENVIRONMENT') + '_JENKINS_BUILD_EMAIL_TEMPLATE_ID')
-    JENKINS_BUILD_LETTER_TEMPLATE_ID = os.environ.get(
-        os.environ.get('ENVIRONMENT') + '_JENKINS_BUILD_LETTER_TEMPLATE_ID')
-    NOTIFY_SERVICE_API_KEY = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_SERVICE_API_KEY')
-    NOTIFY_RESEARCH_MODE_EMAIL = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_MODE_EMAIL')
-    NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD = os.environ.get(
-        os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD')
-    NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT = os.environ.get(
-        os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT')
-    NOTIFY_RESEARCH_SERVICE_ID = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_SERVICE_ID')
-    NOTIFY_RESEARCH_SERVICE_API_TEST_KEY = os.environ.get(
-        os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_SERVICE_API_TEST_KEY')
-    NOTIFY_RESEARCH_SERVICE_API_KEY = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_SERVICE_API_KEY')
-    NOTIFY_RESEARCH_SERVICE_NAME = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_SERVICE_NAME')
-    NOTIFY_RESEARCH_EMAIL_REPLY_TO = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_EMAIL_REPLY_TO')
-    NOTIFY_RESEARCH_ORGANISATION_ID = os.environ.get(os.environ.get('ENVIRONMENT') + '_NOTIFY_RESEARCH_ORGANISATION_ID')
-    NOTIFY_RESEARCH_SMS_SENDER = 'func tests'
-    NOTIFY_RESEARCH_LETTER_CONTACT = {"address_line_1": "test", "address_line_2": "London", "postcode": "N1"}
-    REGISTRATION_TEMPLATE_ID = 'ece42649-22a8-4d06-b87f-d52d5d3f0a27'
-    INVITATION_TEMPLATE_ID = '4f46df42-f795-4cc4-83bb-65ca312f49cc'
-    VERIFY_CODE_TEMPLATE_ID = '36fb0730-6259-4da1-8a80-c8de22ad4246'
-    EMAIL_AUTH_TEMPLATE_ID = '299726d2-dba6-42b8-8209-30e1d66ea164'
-    ORG_INVITATION_TEMPLATE_ID = '203566f0-d835-47c5-aa06-932439c86573'
-
-    DOCUMENT_DOWNLOAD_API_HOST = os.environ.get(os.environ.get('ENVIRONMENT') + '_DOCUMENT_DOWNLOAD_API_HOST')
-    DOCUMENT_DOWNLOAD_API_KEY = os.environ.get(os.environ.get('ENVIRONMENT') + '_DOCUMENT_DOWNLOAD_API_KEY')
+import pytest
 
 
-class PreviewConfig(Config):
-    SMS_TEMPLATE_ID = os.environ.get('preview_SMS_TEMPLATE_ID')
-    EMAIL_TEMPLATE_ID = os.environ.get('preview_EMAIL_TEMPLATE_ID')
-    JENKINS_BUILD_SMS_TEMPLATE_ID = os.environ.get('preview_JENKINS_BUILD_SMS_TEMPLATE_ID')
-    JENKINS_BUILD_EMAIL_TEMPLATE_ID = os.environ.get('preview_JENKINS_BUILD_EMAIL_TEMPLATE_ID')
-    NOTIFY_RESEARCH_MODE_EMAIL = os.environ.get('preview_NOTIFY_RESEARCH_MODE_EMAIL')
-    NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD = os.environ.get('preview_NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD')
-    NOTIFY_RESEARCH_SERVICE_ID = os.environ.get('preview_NOTIFY_RESEARCH_SERVICE_ID')
-    NOTIFY_RESEARCH_SERVICE_API_KEY = os.environ.get('preview_NOTIFY_RESEARCH_SERVICE_API_KEY')
-    NOTIFY_RESEARCH_SERVICE_NAME = os.environ.get('preview_NOTIFY_RESEARCH_SERVICE_NAME')
-    NOTIFY_RESEARCH_EMAIL_REPLY_TO = os.environ.get('preview_NOTIFY_RESEARCH_EMAIL_REPLY_TO')
-    # seeded organisation
-    NOTIFY_RESEARCH_ORGANISATION_ID = '63b9557c-22ea-42ac-bcba-edaa50e3ae51'
+def generate_unique_email(email, uuid):
+    parts = email.split('@')
+    return "{}+{}@{}".format(parts[0], uuid, parts[1])
 
 
-class StagingConfig(Config):
-    FUNCTIONAL_TEST_SERVICE_NAME = 'Staging FunctionalTest'
-    SMS_TEMPLATE_ID = os.environ.get('staging_SMS_TEMPLATE_ID')
-    EMAIL_TEMPLATE_ID = os.environ.get('staging_EMAIL_TEMPLATE_ID')
-    JENKINS_BUILD_SMS_TEMPLATE_ID = os.environ.get('staging_JENKINS_BUILD_SMS_TEMPLATE_ID')
-    JENKINS_BUILD_EMAIL_TEMPLATE_ID = os.environ.get('staging_JENKINS_BUILD_EMAIL_TEMPLATE_ID')
-    SERVICE_ID = os.environ.get('staging_SERVICE_ID')
-    SERVICE_API_KEY = os.environ.get('staging_API_KEY')
+# global variable
+config = {
+    # static
+    'notification_retry_times': 15,
+    'notification_retry_interval': 5,
+    'provider_retry_times': 12,
+    'provider_retry_interval': 22,
+    'verify_code_retry_times': 8,
+    'verify_code_retry_interval': 9,
+    'functional_test_service_name': 'Functional Test Service_',
+
+    'letter_contact_data': {"address_line_1": "test", "address_line_2": "London", "postcode": "N1"},
+
+    # notify templates
+    'notify_templates': {
+        'email_auth_template_id': '299726d2-dba6-42b8-8209-30e1d66ea164',
+        'invitation_template_id': '4f46df42-f795-4cc4-83bb-65ca312f49cc',
+        'org_invitation_template_id': '203566f0-d835-47c5-aa06-932439c86573',
+        'registration_template_id': 'ece42649-22a8-4d06-b87f-d52d5d3f0a27',
+        'verify_code_template_id': '36fb0730-6259-4da1-8a80-c8de22ad4246',
+    }
+}
 
 
-class LiveConfig(Config):
-    FUNCTIONAL_TEST_SERVICE_NAME = 'Live FunctionalTest'
-    SMS_TEMPLATE_ID = os.environ.get('live_SMS_TEMPLATE_ID')
-    EMAIL_TEMPLATE_ID = os.environ.get('live_EMAIL_TEMPLATE_ID')
-    JENKINS_BUILD_SMS_TEMPLATE_ID = os.environ.get('live_JENKINS_BUILD_SMS_TEMPLATE_ID')
-    JENKINS_BUILD_EMAIL_TEMPLATE_ID = os.environ.get('live_JENKINS_BUILD_EMAIL_TEMPLATE_ID')
-    SERVICE_ID = os.environ.get('live_SERVICE_ID')
-    SERVICE_API_KEY = os.environ.get('live_API_KEY')
+urls = {
+    'dev': {
+        'api': 'http://localhost:6011',
+        'admin': 'http://localhost:6012'
+    },
+    'preview': {
+        'api': 'https://api.notify.works',
+        'admin': 'https://www.notify.works'
+    },
+    'staging': {
+        'api': 'https://api.staging-notify.works',
+        'admin': 'https://www.staging-notify.works'
+    },
+    'live': {
+        'api': 'https://api.notifications.service.gov.uk',
+        'admin': 'https://www.notifications.service.gov.uk'
+    }
+}
+
+
+def setup_config():
+    env = os.environ['ENVIRONMENT'].lower()
+
+    config.update({
+        'notify_api_url': urls[env]['api'],
+        'notify_admin_url': urls[env]['admin'],
+    })
+
+    # (dev, preview)
+    if env in {'dev', 'preview'}:
+        uuid_for_test_run = str(uuid.uuid4())
+
+        config.update({
+            'env': env,
+
+            'service_name': 'Functional Test_{}'.format(uuid_for_test_run),
+
+            'user': {
+                'name': '{}_Functional Test_{}'.format(env, uuid_for_test_run),
+                'email': generate_unique_email(os.environ['FUNCTIONAL_TEST_EMAIL'], uuid_for_test_run),
+                'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
+                'mobile': os.environ['TEST_NUMBER'],
+            },
+
+            'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
+
+            'service': {
+                'id': os.environ['NOTIFY_RESEARCH_SERVICE_ID'],
+                'name': os.environ['NOTIFY_RESEARCH_SERVICE_NAME'],
+
+                'seeded_user': {
+                    'email': os.environ['NOTIFY_RESEARCH_MODE_EMAIL'],
+                    'password': os.environ['NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD'],
+                },
+                'api_live_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_KEY'],
+                'api_test_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_TEST_KEY'],
+
+                # email address of seeded email auth user
+                'email_auth_account': os.environ['NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT'],
+                'organisation_id': os.environ['NOTIFY_RESEARCH_ORGANISATION_ID'],
+
+                'email_reply_to': os.environ['NOTIFY_RESEARCH_EMAIL_REPLY_TO'],
+
+                'sms_sender_text': 'func tests',
+
+                'templates': {
+                    'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
+                    'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
+                    'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
+                }
+            },
+
+            'document_download': {
+                'api_host': os.environ['DOCUMENT_DOWNLOAD_API_HOST'],
+                'api_key': os.environ['DOCUMENT_DOWNLOAD_API_KEY']
+            }
+        })
+    elif env in {'staging', 'live'}:
+        # staging and live run the same simple smoke tests
+        config.update({
+            'env': os.environ['ENVIRONMENT'],
+            'name': '{} Functional Tests'.format(env),
+            'user': {
+                'email': os.environ['FUNCTIONAL_TEST_EMAIL'],
+                'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
+                'mobile': os.environ['TEST_NUMBER'],
+            },
+
+            'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
+
+            # this is either a live service or in research mode, depending on what tests are running
+            # (provider vs functional smoke tests)
+            'service': {
+                'id': os.environ['SERVICE_ID'],
+                'api_key': os.environ['API_KEY'],
+
+                'templates': {
+                    'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
+                    'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
+                    'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
+                }
+            }
+        })
+    else:
+        pytest.fail('env "{}" not one of dev, preview, staging, live'.format(env))

--- a/config.py
+++ b/config.py
@@ -53,88 +53,96 @@ urls = {
 }
 
 
-def setup_config():
+def setup_shared_config():
+    """
+    Used by all tests
+    """
     env = os.environ['ENVIRONMENT'].lower()
 
-    # (dev, preview)
-    if env in {'dev', 'preview'}:
-        uuid_for_test_run = str(uuid.uuid4())
-
-        config.update({
-            'env': env,
-
-            'service_name': 'Functional Test_{}'.format(uuid_for_test_run),
-
-            'user': {
-                'name': '{}_Functional Test_{}'.format(env, uuid_for_test_run),
-                'email': generate_unique_email(os.environ['FUNCTIONAL_TEST_EMAIL'], uuid_for_test_run),
-                'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
-                'mobile': os.environ['TEST_NUMBER'],
-            },
-
-            'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
-
-            'service': {
-                'id': os.environ['NOTIFY_RESEARCH_SERVICE_ID'],
-                'name': os.environ['NOTIFY_RESEARCH_SERVICE_NAME'],
-
-                'seeded_user': {
-                    'email': os.environ['NOTIFY_RESEARCH_MODE_EMAIL'],
-                    'password': os.environ['NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD'],
-                },
-                'api_live_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_KEY'],
-                'api_test_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_TEST_KEY'],
-
-                # email address of seeded email auth user
-                'email_auth_account': os.environ['NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT'],
-                'organisation_id': os.environ['NOTIFY_RESEARCH_ORGANISATION_ID'],
-
-                'email_reply_to': os.environ['NOTIFY_RESEARCH_EMAIL_REPLY_TO'],
-
-                'sms_sender_text': 'func tests',
-
-                'templates': {
-                    'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
-                    'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
-                    'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
-                }
-            },
-
-            'document_download': {
-                'api_host': os.environ['DOCUMENT_DOWNLOAD_API_HOST'],
-                'api_key': os.environ['DOCUMENT_DOWNLOAD_API_KEY']
-            }
-        })
-    elif env in {'staging', 'live'}:
-        # staging and live run the same simple smoke tests
-        config.update({
-            'env': os.environ['ENVIRONMENT'],
-            'name': '{} Functional Tests'.format(env),
-            'user': {
-                'email': os.environ['FUNCTIONAL_TEST_EMAIL'],
-                'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
-                'mobile': os.environ['TEST_NUMBER'],
-            },
-
-            'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
-
-            # this is either a live service or in research mode, depending on what tests are running
-            # (provider vs functional smoke tests)
-            'service': {
-                'id': os.environ['SERVICE_ID'],
-                'api_key': os.environ['API_KEY'],
-
-                'templates': {
-                    'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
-                    'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
-                    'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
-                }
-            }
-        })
-    else:
+    if env not in {'dev', 'preview', 'staging', 'live'}:
         pytest.fail('env "{}" not one of dev, preview, staging, live'.format(env))
 
     config.update({
+        'env': env,
         'notify_api_url': urls[env]['api'],
         'notify_admin_url': urls[env]['admin'],
+    })
+
+
+def setup_preview_dev_config():
+    uuid_for_test_run = str(uuid.uuid4())
+
+    config.update({
+        'service_name': 'Functional Test_{}'.format(uuid_for_test_run),
+
+        'user': {
+            'name': '{}_Functional Test_{}'.format(config['env'], uuid_for_test_run),
+            'email': generate_unique_email(os.environ['FUNCTIONAL_TEST_EMAIL'], uuid_for_test_run),
+            'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
+            'mobile': os.environ['TEST_NUMBER'],
+        },
+
+        'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
+
+        'service': {
+            'id': os.environ['NOTIFY_RESEARCH_SERVICE_ID'],
+            'name': os.environ['NOTIFY_RESEARCH_SERVICE_NAME'],
+
+            'seeded_user': {
+                'email': os.environ['NOTIFY_RESEARCH_MODE_EMAIL'],
+                'password': os.environ['NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD'],
+            },
+            'api_live_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_KEY'],
+            'api_test_key': os.environ['NOTIFY_RESEARCH_SERVICE_API_TEST_KEY'],
+
+            # email address of seeded email auth user
+            'email_auth_account': os.environ['NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT'],
+            'organisation_id': os.environ['NOTIFY_RESEARCH_ORGANISATION_ID'],
+
+            'email_reply_to': os.environ['NOTIFY_RESEARCH_EMAIL_REPLY_TO'],
+
+            'sms_sender_text': 'func tests',
+
+            'templates': {
+                'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
+                'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
+                'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
+            }
+        }
+    })
+
+
+def setup_staging_live_config():
+    # staging and live run the same simple smoke tests
+    config.update({
+        'name': '{} Functional Tests'.format(config['env']),
+        'user': {
+            'email': os.environ['FUNCTIONAL_TEST_EMAIL'],
+            'password': os.environ['FUNCTIONAL_TEST_PASSWORD'],
+            'mobile': os.environ['TEST_NUMBER'],
+        },
+
+        'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
+
+        # this is either a live service or in research mode, depending on what tests are running
+        # (provider vs functional smoke tests)
+        'service': {
+            'id': os.environ['SERVICE_ID'],
+            'api_key': os.environ['API_KEY'],
+
+            'templates': {
+                'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
+                'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],
+                'letter': os.environ['JENKINS_BUILD_LETTER_TEMPLATE_ID'],
+            }
+        }
+    })
+
+
+def setup_document_download_config():
+    config.update({
+        'document_download': {
+            'api_host': os.environ['DOCUMENT_DOWNLOAD_API_HOST'],
+            'api_key': os.environ['DOCUMENT_DOWNLOAD_API_KEY']
+        }
     })

--- a/config.py
+++ b/config.py
@@ -56,11 +56,6 @@ urls = {
 def setup_config():
     env = os.environ['ENVIRONMENT'].lower()
 
-    config.update({
-        'notify_api_url': urls[env]['api'],
-        'notify_admin_url': urls[env]['admin'],
-    })
-
     # (dev, preview)
     if env in {'dev', 'preview'}:
         uuid_for_test_run = str(uuid.uuid4())
@@ -138,3 +133,8 @@ def setup_config():
         })
     else:
         pytest.fail('env "{}" not one of dev, preview, staging, live'.format(env))
+
+    config.update({
+        'notify_api_url': urls[env]['api'],
+        'notify_admin_url': urls[env]['admin'],
+    })

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -12,8 +12,8 @@ echo -n "" > docker.env
 [ -n "$ENVIRONMENT" ] || exit_with_msg "ENVIRONMENT is not defined, generating empty docker.env" 0
 
 env_vars=(
+    ENVIRONMENT
     TEST_NUMBER
-    FUNCTIONAL_TEST_NAME
     FUNCTIONAL_TEST_EMAIL
     FUNCTIONAL_TEST_PASSWORD
     NOTIFY_ADMIN_URL
@@ -23,11 +23,7 @@ env_vars=(
     EMAIL_TEMPLATE_ID
     SERVICE_ID
     API_KEY
-    DESKPRO_PERSON_EMAIL
-    DESKPRO_DEPT_ID
-    DESKPRO_ASSIGNED_AGENT_TEAM_ID
-    DESKPRO_API_HOST
-    DESKPRO_API_KEY
+    ZENDESK_API_KEY
     NOTIFY_RESEARCH_MODE_EMAIL
     NOTIFY_RESEARCH_MODE_EMAIL_PASSWORD
     NOTIFY_RESEARCH_SERVICE_ID
@@ -44,7 +40,7 @@ env_vars=(
 )
 
 for env_var in "${env_vars[@]}"; do
-    echo "${ENVIRONMENT}_${env_var}=${!env_var}" >> docker.env
+    echo "${env_var}=${!env_var}" >> docker.env
 done
 
 echo "BUILD_ID=$BUILD_ID" >> docker.env

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -2,25 +2,19 @@
 
 set -eo pipefail
 
-function exit_with_msg {
-    echo $1
-    exit $2
-}
+[ -n "$ENVIRONMENT" ] || echo "ENVIRONMENT is not defined, generating empty docker.env" && exit 1
 
 echo -n "" > docker.env
 
-[ -n "$ENVIRONMENT" ] || exit_with_msg "ENVIRONMENT is not defined, generating empty docker.env" 0
-
 env_vars=(
     ENVIRONMENT
+    BUILD_ID
     TEST_NUMBER
     FUNCTIONAL_TEST_EMAIL
     FUNCTIONAL_TEST_PASSWORD
     NOTIFY_ADMIN_URL
     NOTIFY_API_URL
     NOTIFY_SERVICE_API_KEY
-    SMS_TEMPLATE_ID
-    EMAIL_TEMPLATE_ID
     SERVICE_ID
     API_KEY
     ZENDESK_API_KEY
@@ -35,12 +29,13 @@ env_vars=(
     NOTIFY_RESEARCH_SERVICE_NAME
     NOTIFY_RESEARCH_EMAIL_REPLY_TO
     NOTIFY_RESEARCH_SERVICE_EMAIL_AUTH_ACCOUNT
+    NOTIFY_RESEARCH_ORGANISATION_ID
     DOCUMENT_DOWNLOAD_API_HOST
     DOCUMENT_DOWNLOAD_API_KEY
 )
 
 for env_var in "${env_vars[@]}"; do
-    echo "${env_var}=${!env_var}" >> docker.env
+    if [ -n "${!env_var}" ]; then
+      echo "${env_var}=${!env_var}" >> docker.env
+    fi
 done
-
-echo "BUILD_ID=$BUILD_ID" >> docker.env

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-[ -n "$ENVIRONMENT" ] || echo "ENVIRONMENT is not defined, generating empty docker.env" && exit 1
+[ -n "$ENVIRONMENT" ] || (echo "ENVIRONMENT is not defined" && exit 1)
 
 echo -n "" > docker.env
 

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -31,10 +31,13 @@ display_result $? 1 "Code style check"
 
 # get status page for env under tests and spit out to console
 function display_status {
-  url=$ENVIRONMENT'_NOTIFY_ADMIN_URL'
-  echo 'Build info:'
-  curl -sSL ${!url}/'_status'
-  echo
+  python -c "
+import requests
+from config import config, setup_config
+setup_config()
+print('Build info:')
+print(requests.get(config['notify_admin_url'] + '/_status').json())
+"
 }
 
 

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -8,7 +8,6 @@
 # Use default environment vars for localhost if not already set
 
 set -o pipefail
-[ "$IGNORE_ENVIRONMENT_SH" = "1" ] || source environment.sh 2> /dev/null
 
 function display_result {
   RESULT=$1
@@ -29,10 +28,6 @@ fi
 
 flake8 .
 display_result $? 1 "Code style check"
-
-environment=${ENVIRONMENT:=preview}
-export ENVIRONMENT=$environment
-
 
 # get status page for env under tests and spit out to console
 function display_status {
@@ -57,20 +52,15 @@ if [ -d logs ]; then
 fi
 mkdir logs
 
+echo "Running $ENVIRONMENT tests"
+display_status $ENVIRONMENT
+
 case $ENVIRONMENT in
     staging|live)
-      echo Running $ENVIRONMENT tests
-      display_status $ENVIRONMENT
       py.test -x -v tests/functional/staging_and_prod/
       ;;
-    preview)
-      echo Running $ENVIRONMENT tests
-      display_status $ENVIRONMENT
-      py.test -x -v tests/functional/preview_and_dev/
-      ;;
     *)
-      echo 'Default test run - for' $ENVIRONMENT
-      display_status $ENVIRONMENT
+      # dev, preview
       py.test -x -v tests/functional/preview_and_dev/
       ;;
 esac

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -33,8 +33,8 @@ display_result $? 1 "Code style check"
 function display_status {
   python -c "
 import requests
-from config import config, setup_config
-setup_config()
+from config import config, setup_shared_config
+setup_shared_config()
 print('Build info:')
 print(requests.get(config['notify_admin_url'] + '/_status').json())
 "

--- a/scripts/run_test_script.sh
+++ b/scripts/run_test_script.sh
@@ -36,10 +36,13 @@ export ENVIRONMENT=$environment
 
 # get status page for env under tests and spit out to console
 function display_status {
-  url=$ENVIRONMENT'_NOTIFY_ADMIN_URL'
-  echo 'Build info:'
-  curl -sSL ${!url}/'_status'
-  echo
+  python -c "
+import requests
+from config import config, setup_shared_config
+setup_shared_config()
+print('Build info:')
+print(requests.get(config['notify_admin_url'] + '/_status').json())
+"
 }
 
 # remove any previous screenshots

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,15 @@ from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from notifications_python_client import NotificationsAPIClient
 
 from tests.pages.rollups import sign_in
-from config import config, setup_config
+from config import config, setup_shared_config
 
 
-# this is automatically invoked to set up the config
 @pytest.fixture(scope="session", autouse=True)
-def _profile():
-    setup_config()
+def shared_config():
+    """
+    Setup shared config variables (eg env and urls)
+    """
+    setup_shared_config()
 
 
 @pytest.fixture(scope="module")

--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -1,14 +1,14 @@
 import requests
 from retry.api import retry_call
 
-from config import Config
+from config import config
 
 
 def upload_document(service_id, file_contents):
     response = requests.post(
-        "{}/services/{}/documents".format(Config.DOCUMENT_DOWNLOAD_API_HOST, service_id),
+        "{}/services/{}/documents".format(config['document_download']['api_host'], service_id),
         headers={
-            'Authorization': "Bearer {}".format(Config.DOCUMENT_DOWNLOAD_API_KEY),
+            'Authorization': "Bearer {}".format(config['document_download']['api_key']),
         },
         files={
             'document': file_contents
@@ -23,7 +23,7 @@ def upload_document(service_id, file_contents):
 def test_document_upload_and_download():
     document_url = retry_call(
         upload_document,
-        fargs=[Config.NOTIFY_RESEARCH_SERVICE_ID, 'functional tests file'],
+        fargs=[config['service']['id'], 'functional tests file'],
         tries=3,
         delay=10
     )

--- a/tests/functional/document_download/conftest.py
+++ b/tests/functional/document_download/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from config import setup_document_download_config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def document_download_config():
+    """
+    Setup
+    """
+    setup_document_download_config()

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from config import setup_preview_dev_config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def preview_dev_config():
+    """
+    Setup
+    """
+    setup_preview_dev_config()

--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -1,11 +1,12 @@
+from config import config
 from tests.test_utils import recordtime
 
 from tests.pages.rollups import sign_in_email_auth
 
 
 @recordtime
-def test_email_auth(driver, profile, base_url):
+def test_email_auth(driver):
     # login email auth user
-    sign_in_email_auth(driver, profile)
+    sign_in_email_auth(driver)
     # assert url is research mode service's dashboard
-    assert driver.current_url == base_url + '/services/{}'.format(profile.notify_research_service_id)
+    assert driver.current_url == config['notify_admin_url'] + '/services/{}'.format(config['service']['id'])

--- a/tests/functional/preview_and_dev/test_notify_api_letter.py
+++ b/tests/functional/preview_and_dev/test_notify_api_letter.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 import base64
 from retry.api import retry_call
-from config import Config
+from config import config
 
 from tests.postman import (
     get_notification_by_id_via_api,
@@ -15,25 +15,27 @@ from tests.test_utils import assert_notification_body, recordtime
 
 
 @recordtime
-def test_send_letter_notification_via_api(profile, seeded_client_using_test_key):
+def test_send_letter_notification_via_api(seeded_client_using_test_key):
     notification_id = send_notification_via_api(
-        seeded_client_using_test_key, profile.jenkins_build_letter_template_id,
-        profile.notify_research_letter_contact, 'letter'
+        seeded_client_using_test_key,
+        config['service']['templates']['letter'],
+        config['letter_contact_data'],
+        'letter'
     )
 
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.RECEIVED],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
     assert_notification_body(notification_id, notification)
 
 
 @recordtime
-def test_send_precompiled_letter_notification_via_api(profile, seeded_client_using_test_key):
+def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_key):
 
-    reference = profile.name.replace(" ", "_") + "_delivered"
+    reference = config['service_name'].replace(" ", "_") + "_delivered"
 
     notification_id = send_precompiled_letter_via_api(
         reference,
@@ -44,20 +46,20 @@ def test_send_precompiled_letter_notification_via_api(profile, seeded_client_usi
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.PENDING_VIRUS_CHECK],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
 
     assert reference == notification['reference']
 
 
 @recordtime
-def test_send_precompiled_letter_with_virus_notification_via_api(profile, seeded_client_using_test_key):
+def test_send_precompiled_letter_with_virus_notification_via_api(seeded_client_using_test_key):
 
     # This uses a file which drops the Eicar test virus into the temp directory
     # The dropper code _should_ be detected before the eicar virus
 
-    reference = profile.name.replace(" ", "_") + "_virus_scan_failed"
+    reference = config['service_name'].replace(" ", "_") + "_virus_scan_failed"
 
     notification_id = send_precompiled_letter_via_api(
         reference,
@@ -68,8 +70,8 @@ def test_send_precompiled_letter_with_virus_notification_via_api(profile, seeded
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.PENDING_VIRUS_CHECK],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
 
     assert reference == notification['reference']

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -13,13 +13,13 @@ from tests.pages import (
 
 
 @recordtime
-def test_registration_and_invite_flow(driver, profile, base_url):
-    do_user_registration(driver, profile, base_url)
+def test_registration_and_invite_flow(driver):
+    do_user_registration(driver)
     do_user_can_add_reply_to_email_to_service(driver)
     do_user_can_update_reply_to_email_to_service(driver)
     do_user_can_update_sms_sender_of_service(driver)
     do_user_can_add_sms_sender_to_service(driver)
-    do_user_can_invite_someone_to_notify(driver, profile, base_url)
+    do_user_can_invite_someone_to_notify(driver)
 
 
 def do_user_can_update_sms_sender_of_service(driver):

--- a/tests/functional/staging_and_prod/conftest.py
+++ b/tests/functional/staging_and_prod/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from config import setup_staging_live_config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def staging_live_config():
+    """
+    Setup
+    """
+    setup_staging_live_config()

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
@@ -1,5 +1,5 @@
 from retry.api import retry_call
-from config import Config
+from config import config
 
 from tests.postman import (
     send_notification_via_api,
@@ -11,16 +11,16 @@ from tests.test_utils import assert_notification_body, recordtime
 
 
 @recordtime
-def test_send_email_notification_via_api(profile, client):
+def test_send_email_notification_via_api(client):
     notification_id = send_notification_via_api(
-        client, profile.jenkins_build_email_template_id,
-        profile.email, 'email',
+        client, config['service']['templates']['email'],
+        config['user']['email'], 'email',
     )
 
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, NotificationStatuses.SENT],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
     assert_notification_body(notification_id, notification)

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
@@ -1,5 +1,5 @@
 from retry.api import retry_call
-from config import Config
+from config import config
 
 from tests.postman import (
     send_notification_via_api,
@@ -11,16 +11,16 @@ from tests.test_utils import assert_notification_body, recordtime
 
 
 @recordtime
-def test_send_sms_notification_via_api(profile, client):
+def test_send_sms_notification_via_api(client):
     notification_id = send_notification_via_api(
-        client, profile.jenkins_build_sms_template_id,
-        profile.mobile, 'sms'
+        client, config['service']['templates']['sms'],
+        config['user']['mobile'], 'sms'
     )
 
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, NotificationStatuses.SENT],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
     assert_notification_body(notification_id, notification)

--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -1,5 +1,5 @@
 from retry.api import retry_call
-from config import Config
+from config import config
 
 from tests.pages import UploadCsvPage
 
@@ -13,23 +13,23 @@ from tests.test_utils import assert_notification_body, recordtime
 
 
 @recordtime
-def test_admin(driver, base_url, client, profile, login_user):
+def test_admin(driver, client, login_user):
     upload_csv_page = UploadCsvPage(driver)
-    csv_sms_notification_id = send_notification_via_csv(profile, upload_csv_page, 'sms')
+    csv_sms_notification_id = send_notification_via_csv(upload_csv_page, 'sms')
     csv_sms_notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, csv_sms_notification_id, NotificationStatuses.SENT],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
     assert_notification_body(csv_sms_notification_id, csv_sms_notification)
 
-    csv_email_notification_id = send_notification_via_csv(profile, upload_csv_page, 'email')
+    csv_email_notification_id = send_notification_via_csv(upload_csv_page, 'email')
     csv_email_notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, csv_email_notification_id, NotificationStatuses.SENT],
-        tries=Config.NOTIFICATION_RETRY_TIMES,
-        delay=Config.NOTIFICATION_RETRY_INTERVAL
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
     )
 
     assert_notification_body(csv_email_notification_id, csv_email_notification)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import NoSuchElementException, StaleElementRefer
 from selenium.common.exceptions import TimeoutException
 
 from retry import retry
-from config import Config
+from config import config
 
 from tests.pages.element import (
     EmailInputElement,
@@ -53,10 +53,10 @@ class RetryException(Exception):
 
 class BasePage(object):
 
-    base_url = Config.NOTIFY_ADMIN_URL
     sign_out_link = NavigationLocators.SIGN_OUT_LINK
 
     def __init__(self, driver):
+        self.base_url = config['notify_admin_url']
         self.driver = driver
 
     def wait_for_invisible_element(self, locator):
@@ -122,11 +122,11 @@ class RegistrationPage(BasePage):
     def is_current(self):
         return self.wait_until_url_is(self.base_url + '/register')
 
-    def register(self, profile):
-        self.name_input = profile.name
-        self.email_input = profile.email
-        self.mobile_input = profile.mobile
-        self.password_input = profile.password
+    def register(self):
+        self.name_input = config['user']['name']
+        self.email_input = config['user']['email']
+        self.mobile_input = config['user']['mobile']
+        self.password_input = config['user']['password']
         self.click_continue_button()
 
     def click_continue_button(self):
@@ -493,10 +493,10 @@ class RegisterFromInvite(BasePage):
     password_input = PasswordInputElement()
     continue_button = CommonPageLocators.CONTINUE_BUTTON
 
-    def fill_registration_form(self, name, profile):
+    def fill_registration_form(self, name):
         self.name_input = name
-        self.mobile_input = profile.mobile
-        self.password_input = profile.password
+        self.mobile_input = config['user']['mobile']
+        self.password_input = config['user']['password']
 
     def click_continue(self):
         element = self.wait_for_element(RegisterFromInvite.continue_button)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -717,11 +717,6 @@ class OrganisationDashboardPage(BasePage):
         expected = "{}/organisations/{}".format(self.base_url, org_id)
         return self.driver.current_url == expected
 
-    def get_service_names_and_links(self):
-        items = self.driver.find_elements(*self.service_list)
-        print(type(items), items)
-        return []
-
     def click_team_members_link(self):
         element = self.wait_for_element(DashboardPage.team_members_link)
         element.click()

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -1,107 +1,34 @@
-from config import Config
-from tests.pages import (
-    SignInPage,
-    DashboardPage,
-    SendEmailTemplatePage,
-    EditEmailTemplatePage,
-    SendSmsTemplatePage,
-    EditSmsTemplatePage,
-    ApiKeyPage,
-    ShowTemplatesPage,
-    SelectTemplatePage
-)
+from config import config
+from tests.pages import SignInPage
 
 from tests.test_utils import do_verify, do_email_auth_verify
 
 
-def sign_in(driver, test_profile, seeded=False):
-    _sign_in(driver, test_profile, 'seeded' if seeded else 'normal')
-    do_verify(driver, test_profile)
+def sign_in(driver, seeded=False):
+    _sign_in(driver, 'seeded' if seeded else 'normal')
+    do_verify(driver)
 
 
-def sign_in_email_auth(driver, test_profile):
-    _sign_in(driver, test_profile, 'email_auth')
-    assert driver.current_url == Config.NOTIFY_ADMIN_URL + '/two-factor-email-sent'
-    do_email_auth_verify(driver, test_profile)
+def sign_in_email_auth(driver):
+    _sign_in(driver, 'email_auth')
+    assert driver.current_url == config['notify_admin_url'] + '/two-factor-email-sent'
+    do_email_auth_verify(driver)
 
 
-def _sign_in(driver, test_profile, account_type):
+def _sign_in(driver, account_type):
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
     assert sign_in_page.is_current()
-    email, password = _get_email_and_password(test_profile, account_type=account_type)
+    email, password = _get_email_and_password(account_type=account_type)
     sign_in_page.login(email, password)
 
 
-def _get_email_and_password(profile, account_type):
+def _get_email_and_password(account_type):
     if account_type == 'normal':
-        return profile.email, profile.password
+        return config['user']['email'], config['user']['password']
     elif account_type == 'seeded':
-        return profile.notify_research_service_email, profile.notify_research_service_password
+        return config['service']['seeded_user']['email'], config['service']['seeded_user']['password']
     elif account_type == 'email_auth':
-        return profile.notify_research_service_email_auth_account, profile.notify_research_service_password
+        # has the same password as the seeded user
+        return config['service']['email_auth_account'], config['service']['seeded_user']['password']
     raise Exception('unknown account_type {}'.format(account_type))
-
-
-def get_service_templates_and_api_key_for_tests(driver, test_profile):
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.click_templates()
-    service_id = dashboard_page.get_service_id()
-
-    show_templates_page = ShowTemplatesPage(driver)
-    show_templates_page.click_add_new_template()
-
-    select_template_page = SelectTemplatePage(driver)
-    select_template_page.select_email()
-    select_template_page.click_continue()
-
-    new_email_template_page = EditEmailTemplatePage(driver)
-    new_email_template_page.create_template()
-
-    email_template_page = SendEmailTemplatePage(driver)
-    email_template_page.click_edit_template()
-
-    edit_email_template_page = EditEmailTemplatePage(driver)
-    email_template_id = edit_email_template_page.get_id()
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-    dashboard_page.click_templates()
-
-    show_templates_page = ShowTemplatesPage(driver)
-    show_templates_page.click_add_new_template()
-
-    select_template_page = SelectTemplatePage(driver)
-    select_template_page.select_text_message()
-    select_template_page.click_continue()
-
-    new_sms_template = EditSmsTemplatePage(driver)
-    new_sms_template.create_template()
-
-    sms_template_page = SendSmsTemplatePage(driver)
-    sms_template_page.click_edit_template()
-
-    edit_sms_template = EditSmsTemplatePage(driver)
-    sms_template_id = edit_sms_template.get_id()
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-    dashboard_page.click_api_keys_link()
-
-    api_key_page = ApiKeyPage(driver)
-    api_key_page.click_keys_link()
-    api_key_page.click_create_key()
-
-    api_key_page.click_key_type_radio(key_type='team')
-    api_key_page.enter_key_name(key_type='team')
-
-    api_key_page.click_continue()
-    api_key = api_key_page.get_api_key()
-
-    test_profile.service_id = service_id
-    test_profile.jenkins_build_email_template_id = email_template_id
-    test_profile.jenkins_build_sms_template_id = sms_template_id
-    test_profile.api_key = api_key
-
-    return {'service_id': service_id, 'api_key': api_key}

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -1,7 +1,9 @@
 import os
 
-from tests.test_utils import create_temp_csv, RetryException
 from notifications_python_client.errors import HTTPError
+
+from config import config
+from tests.test_utils import create_temp_csv, RetryException
 
 
 def send_notification_via_api(client, template_id, to, message_type):
@@ -24,19 +26,19 @@ def send_precompiled_letter_via_api(reference, client, pdf_file):
     return resp_json['id']
 
 
-def send_notification_via_csv(profile, upload_csv_page, message_type, seeded=False):
-    service_id = profile.notify_research_service_id if seeded else profile.service_id
-    email = profile.notify_research_service_email if seeded else profile.email
-    letter_contact = profile.notify_research_letter_contact if seeded else None
+def send_notification_via_csv(upload_csv_page, message_type, seeded=False):
+    service_id = config['service']['id'] if seeded else config['service']['id']
+    email = config['service']['seeded_user']['email'] if seeded else config['user']['email']
+    letter_contact = config['letter_contact_data']
 
     if message_type == 'sms':
-        template_id = profile.jenkins_build_sms_template_id
-        directory, filename = create_temp_csv({'phone number': profile.mobile})
+        template_id = config['service']['templates']['sms']
+        directory, filename = create_temp_csv({'phone number': config['user']['mobile']})
     elif message_type == 'email':
-        template_id = profile.jenkins_build_email_template_id
+        template_id = config['service']['templates']['email']
         directory, filename = create_temp_csv({'email address': email})
     elif message_type == 'letter':
-        template_id = profile.jenkins_build_letter_template_id
+        template_id = config['service']['templates']['letter']
         directory, filename = create_temp_csv(letter_contact)
 
     upload_csv_page.go_to_upload_csv_for_service_and_template(service_id, template_id)

--- a/tests/provider_delivery/test_provider_delivery_email.py
+++ b/tests/provider_delivery/test_provider_delivery_email.py
@@ -1,5 +1,5 @@
 from retry.api import retry_call
-from config import Config
+from config import config
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api,
@@ -9,15 +9,15 @@ from tests.postman import (
 from tests.test_utils import assert_notification_body
 
 
-def test_provider_email_delivery_via_api(profile, client):
+def test_provider_email_delivery_via_api(client):
     notification_id = send_notification_via_api(
-        client, profile.jenkins_build_email_template_id,
-        profile.email, 'email'
+        client, config['service']['templates']['email'],
+        config['user']['email'], 'email'
     )
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, NotificationStatuses.DELIVERED],
-        tries=Config.PROVIDER_RETRY_TIMES,
-        delay=Config.PROVIDER_RETRY_INTERVAL
+        tries=config['provider_retry_times'],
+        delay=config['provider_retry_interval']
     )
     assert_notification_body(notification_id, notification)

--- a/tests/provider_delivery/test_provider_delivery_sms.py
+++ b/tests/provider_delivery/test_provider_delivery_sms.py
@@ -1,5 +1,5 @@
 from retry.api import retry_call
-from config import Config
+from config import config
 from tests.postman import (
     send_notification_via_api,
     get_notification_by_id_via_api,
@@ -9,15 +9,16 @@ from tests.postman import (
 from tests.test_utils import assert_notification_body
 
 
-def test_provider_sms_delivery_via_api(profile, client):
+def test_provider_sms_delivery_via_api(client):
     notification_id = send_notification_via_api(
-        client, profile.jenkins_build_sms_template_id,
-        profile.mobile, 'sms'
+        client, config['service']['templates']['sms'],
+        config['user']['mobile'], 'sms'
     )
+
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[client, notification_id, NotificationStatuses.DELIVERED],
-        tries=Config.PROVIDER_RETRY_TIMES,
-        delay=Config.PROVIDER_RETRY_INTERVAL
+        tries=config['provider_retry_times'],
+        delay=config['provider_retry_interval']
     )
     assert_notification_body(notification_id, notification)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,9 +217,6 @@ def get_verify_code_from_api():
 
 @retry(RetryException, tries=config['notification_retry_times'], delay=config['notification_retry_interval'])
 def get_notification_via_api(template_id, api_key, sent_to):
-    from pprint import pprint
-    print('get_notification_via_api')
-    pprint(config)
     client = NotificationsAPIClient(
         base_url=config['notify_api_url'],
         api_key=api_key

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from retry import retry
 from notifications_python_client.notifications import NotificationsAPIClient
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
-from config import Config
+from config import config, generate_unique_email
 from tests.pages import (
     AddServicePage,
     DashboardPage,
@@ -59,15 +59,10 @@ def assert_notification_body(notification_id, notification):
     assert 'The quick brown fox jumped over the lazy dog' in notification['body']
 
 
-def generate_unique_email(email, uuid):
-    parts = email.split('@')
-    return "{}+{}@{}".format(parts[0], uuid, parts[1])
-
-
-def get_link(profile, template_id, email):
+def get_link(template_id, email):
     email_body = get_notification_via_api(
         template_id,
-        profile.notify_service_api_key,
+        config['notify_service_api_key'],
         email
     )
     match = re.search(r'http[s]?://\S+', email_body, re.MULTILINE)
@@ -77,10 +72,10 @@ def get_link(profile, template_id, email):
         pytest.fail("Couldn't get the link from the email")
 
 
-@retry(RetryException, tries=Config.VERIFY_CODE_RETRY_TIMES, delay=Config.VERIFY_CODE_RETRY_INTERVAL)
-def do_verify(driver, profile):
+@retry(RetryException, tries=config['verify_code_retry_times'], delay=config['verify_code_retry_interval'])
+def do_verify(driver):
     try:
-        verify_code = get_verify_code_from_api(profile)
+        verify_code = get_verify_code_from_api()
         verify_page = VerifyPage(driver)
         verify_page.verify(verify_code)
         driver.find_element_by_class_name('error-message')
@@ -93,13 +88,12 @@ def do_verify(driver, profile):
         raise RetryException
 
 
-@retry(RetryException, tries=Config.VERIFY_CODE_RETRY_TIMES, delay=Config.VERIFY_CODE_RETRY_INTERVAL)
-def do_email_auth_verify(driver, profile):
+@retry(RetryException, tries=config['verify_code_retry_times'], delay=config['verify_code_retry_interval'])
+def do_email_auth_verify(driver):
     try:
         login_link = get_link(
-            profile,
-            profile.email_auth_template_id,
-            profile.notify_research_service_email_auth_account
+            config['notify_templates']['email_auth_template_id'],
+            config['service']['email_auth_account']
         )
         driver.get(login_link)
         driver.find_element_by_class_name('banner-dangerous')
@@ -111,7 +105,7 @@ def do_email_auth_verify(driver, profile):
         raise RetryException
 
 
-def do_user_registration(driver, profile, base_url):
+def do_user_registration(driver):
     main_page = MainPage(driver)
     main_page.get()
     main_page.click_set_up_account()
@@ -119,30 +113,28 @@ def do_user_registration(driver, profile, base_url):
     registration_page = RegistrationPage(driver)
     assert registration_page.is_current()
 
-    registration_page.register(profile)
+    registration_page.register()
 
-    assert driver.current_url == base_url + '/registration-continue'
+    assert driver.current_url == config['notify_admin_url'] + '/registration-continue'
 
-    registration_link = get_link(profile,
-                                 profile.registration_template_id,
-                                 profile.email)
+    registration_link = get_link(config['notify_templates']['registration_template_id'], config['user']['email'])
 
     driver.get(registration_link)
 
-    do_verify(driver, profile)
+    do_verify(driver)
 
     add_service_page = AddServicePage(driver)
     assert add_service_page.is_current()
-    add_service_page.add_service(profile.service_name)
+    add_service_page.add_service(config['service_name'])
 
     dashboard_page = DashboardPage(driver)
     service_id = dashboard_page.get_service_id()
     dashboard_page.go_to_dashboard_for_service(service_id)
 
-    assert dashboard_page.h2_is_service_name(profile.service_name)
+    assert dashboard_page.h2_is_service_name(config['service_name'])
 
 
-def do_user_can_invite_someone_to_notify(driver, profile, base_url):
+def do_user_can_invite_someone_to_notify(driver):
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.click_team_members_link()
@@ -155,38 +147,38 @@ def do_user_can_invite_someone_to_notify(driver, profile, base_url):
 
     invited_user_randomness = str(uuid.uuid1())
     invited_user_name = 'Invited User ' + invited_user_randomness
-    invite_email = generate_unique_email(profile.email, invited_user_randomness)
+    invite_email = generate_unique_email(config['user']['email'], invited_user_randomness)
 
     invite_user_page.fill_invitation_form(invite_email, send_messages=True)
     invite_user_page.send_invitation()
     invite_user_page.sign_out()
-    invite_user_page.wait_until_url_is(base_url)
+    invite_user_page.wait_until_url_is(config['notify_admin_url'])
 
     # next part of interaction is from point of view of invitee
     # i.e. after visting invite_link we'll be registering using invite_email
     # but use same mobile number and password as profile
 
-    invite_link = get_link(profile, profile.invitation_template_id, invite_email)
+    invite_link = get_link(config['notify_templates']['invitation_template_id'], invite_email)
     driver.get(invite_link)
     register_from_invite_page = RegisterFromInvite(driver)
-    register_from_invite_page.fill_registration_form(invited_user_name, profile)
+    register_from_invite_page.fill_registration_form(invited_user_name)
     register_from_invite_page.click_continue()
 
-    do_verify(driver, profile)
+    do_verify(driver)
     dashboard_page = DashboardPage(driver)
     service_id = dashboard_page.get_service_id()
     dashboard_page.go_to_dashboard_for_service(service_id)
 
-    assert dashboard_page.h2_is_service_name(profile.service_name)
+    assert dashboard_page.h2_is_service_name(config['service_name'])
 
     dashboard_page.sign_out()
-    dashboard_page.wait_until_url_is(base_url)
+    dashboard_page.wait_until_url_is(config['notify_admin_url'])
 
 
-def do_edit_and_delete_email_template(profile, driver):
+def do_edit_and_delete_email_template(driver):
     test_name = 'edit/delete test'
     dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service(profile.notify_research_service_id)
+    dashboard_page.go_to_dashboard_for_service(config['service']['id'])
     dashboard_page.click_templates()
 
     existing_templates = [x.text for x in driver.find_elements_by_class_name('message-name')]
@@ -210,11 +202,11 @@ def do_edit_and_delete_email_template(profile, driver):
     assert [x.text for x in driver.find_elements_by_class_name('message-name')] == existing_templates
 
 
-def get_verify_code_from_api(profile):
+def get_verify_code_from_api():
     verify_code_message = get_notification_via_api(
-        Config.VERIFY_CODE_TEMPLATE_ID,
-        Config.NOTIFY_SERVICE_API_KEY,
-        profile.mobile
+        config['notify_templates']['verify_code_template_id'],
+        config['notify_service_api_key'],
+        config['user']['mobile']
     )
     m = re.search(r'\d{5}', verify_code_message)
     if not m:
@@ -223,10 +215,13 @@ def get_verify_code_from_api(profile):
     return m.group(0)
 
 
-@retry(RetryException, tries=Config.NOTIFICATION_RETRY_TIMES, delay=Config.NOTIFICATION_RETRY_INTERVAL)
+@retry(RetryException, tries=config['notification_retry_times'], delay=config['notification_retry_interval'])
 def get_notification_via_api(template_id, api_key, sent_to):
+    from pprint import pprint
+    print('get_notification_via_api')
+    pprint(config)
     client = NotificationsAPIClient(
-        base_url=Config.NOTIFY_API_URL,
+        base_url=config['notify_api_url'],
         api_key=api_key
     )
     resp = client.get('v2/notifications', params={'include_jobs': True})


### PR DESCRIPTION
## Why I've done:

Frustration points:
* Long variable names (eg `profile.notify_research_service_api_test_key`)
* Mix of `Config.SOME_VARIABLE` and `profile.some_variable` used throughout.
* often passing `profile` fixture around to lots of helper functions
* confusing debugging due to `os.environ.get` leading to some variables being `None`
* lengthy config file full of duplication - every line has a `os.environ.get(os.environ.get('ENVIRONMENT') + '_SOME_VARIABLE')`
* lots of duplication of env var busy-work between config.py and conftest.py
* hard to tell which variables are associated with which service (think notify vs seeded etc)

## What I've done:

* no longer provide api/admin URLs (they're not secret)
* remove a couple of other things we don't use
* config is now a dict rather than a class, populated through an autouse fixture. This means there are no more `environ.get`. it will load the vars needed for that test run, if they aren't there it'll keyerror.
* remove the profile fixture - now you should say `from config import config`.
* remove prefixes from environment variables. Put your vars in separate
  files. For example, have an `environment_preview.sh`, an `environment_dev.sh`, etc etc. *YOU WILL NEED TO UPDATE YOUR LOCAL ENVIRONMENT FILES*
* can't use curl to print out the build now because we don't know the base url until python time - so a little in-line python script is used
* simplify generate_docker_env - now there's some duplication but it's a much simpler bash script that just pastes stuff into the file rather than looping through vars.