### PR TITLE
update doc download test to send a "real" pdf

### DIFF
--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -15,19 +15,21 @@ def upload_document(service_id, file_contents):
         }
     )
 
-    response.raise_for_status()
+    json = response.json()
+    assert 'error' not in json, 'Status code {}'.format(response.status_code)
 
-    return response.json()['document']['url']
+    return json['document']['url']
 
 
 def test_document_upload_and_download():
     document_url = retry_call(
         upload_document,
-        fargs=[config['service']['id'], 'functional tests file'],
+        # add PDF header to trick doc download into thinking its a real pdf
+        fargs=[config['service']['id'], '%PDF-1.4 functional tests file'],
         tries=3,
         delay=10
     )
 
     downloaded_document = requests.get(document_url)
 
-    assert downloaded_document.text == 'functional tests file'
+    assert downloaded_document.text == '%PDF-1.4 functional tests file'


### PR DESCRIPTION
previously it was sending text - but the latest version of doc dl on preview only accepts PDFs. it does this by checking the file we send for the magic pdf bytes, so make sure they're present in the data.

Also, change the assert from a raise_for_status to a check of the response json so that we can see errors