### PR TITLE
get direct file URL from document download

### DIFF
--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -18,7 +18,7 @@ def upload_document(service_id, file_contents):
     json = response.json()
     assert 'error' not in json, 'Status code {}'.format(response.status_code)
 
-    return json['document']['url']
+    return json['document']['direct_file_url']
 
 
 def test_document_upload_and_download():


### PR DESCRIPTION
the `url` field of the response json now directs you to the frontend user journey. We still return the direct file URL though, so lets use that instead.

co-depends on https://github.com/alphagov/document-download-api/pull/13