### PR TITLE
[do not merge] Remove include_jobs parameter from test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -238,7 +238,7 @@ def get_notification_via_api(template_id, api_key, sent_to):
         base_url=config['notify_api_url'],
         api_key=api_key
     )
-    resp = client.get('v2/notifications', params={'include_jobs': True})
+    resp = client.get('v2/notifications')
     for notification in resp['notifications']:
         t_id = notification['template']['id']
         to = notification['email_address'] or notification['phone_number']


### PR DESCRIPTION
The notifications-api endpoint now returns notifications sent by a job (see https://github.com/alphagov/notifications-api/pull/2139), so there is no longer the option to pass the `include_jobs` parameter in.

[Pivotal story](https://www.pivotaltracker.com/story/show/160757291)