### PR TITLE
avoid validation errors in one_page_pdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask>=0.11.1
 Flask-Cache==0.13.1
-requests==2.18.4
+requests==2.19.1
 beautifulsoup4>=4.5.1
 flake8==3.5.0
-pytest==3.8.0
+pytest==3.9.1
 retry==0.9.2
 selenium==3.14.1
 notifications-python-client==5.2.0

--- a/tests/functional/preview_and_dev/test_notify_api_letter.py
+++ b/tests/functional/preview_and_dev/test_notify_api_letter.py
@@ -10,7 +10,7 @@ from tests.postman import (
     NotificationStatuses
 )
 
-from tests.functional.preview_and_dev.consts import one_page_pdf, pdf_with_virus
+from tests.functional.preview_and_dev.consts import multi_page_pdf, pdf_with_virus
 from tests.test_utils import assert_notification_body, recordtime
 
 
@@ -40,7 +40,7 @@ def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_k
     notification_id = send_precompiled_letter_via_api(
         reference,
         seeded_client_using_test_key,
-        BytesIO(base64.b64decode(one_page_pdf))
+        BytesIO(base64.b64decode(multi_page_pdf))
     )
 
     notification = retry_call(

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -10,7 +10,7 @@ from config import config
 from selenium.common.exceptions import TimeoutException
 
 from tests.decorators import retry_on_stale_element_exception
-from tests.functional.preview_and_dev.consts import one_page_pdf, pdf_with_virus, preview_error
+from tests.functional.preview_and_dev.consts import multi_page_pdf, pdf_with_virus, preview_error
 
 from tests.postman import (
     send_notification_via_csv,
@@ -174,7 +174,7 @@ def test_view_precompiled_letter_message_log_delivered(
     send_precompiled_letter_via_api(
         reference,
         seeded_client_using_test_key,
-        BytesIO(base64.b64decode(one_page_pdf))
+        BytesIO(base64.b64decode(multi_page_pdf))
     )
 
     api_integration_page = ApiIntegrationPage(driver)
@@ -203,7 +203,7 @@ def test_view_precompiled_letter_preview_delivered(
     notification_id = send_precompiled_letter_via_api(
         reference,
         seeded_client_using_test_key,
-        BytesIO(base64.b64decode(one_page_pdf))
+        BytesIO(base64.b64decode(multi_page_pdf))
     )
 
     api_integration_page = ApiIntegrationPage(driver)


### PR DESCRIPTION
one_page_pdf has the fake barcodes etc, so fails validation

multi-page-pdf doesn't, so we can use that to test for expected statuses (delivered etc rather than validation-failed)