### PR TITLE
add pending as a "sent" state

### DIFF
--- a/tests/postman.py
+++ b/tests/postman.py
@@ -52,7 +52,7 @@ class NotificationStatuses:
     PENDING_VIRUS_CHECK = 'pending-virus-check'
     RECEIVED = {'received'}
     DELIVERED = {'delivered', 'temporary-failure', 'permanent-failure'}
-    SENT = RECEIVED | DELIVERED | {'sending'}
+    SENT = RECEIVED | DELIVERED | {'sending', 'pending'}
 
 
 def get_notification_by_id_via_api(client, notification_id, expected_statuses):


### PR DESCRIPTION
firetext return pending if they've handed it off to a provider but are waiting to hear back. this comes after `sending` in the notification flow, so should be considered as equivalent - `SENT` but not `DELIVERED`