### PR TITLE
Fix functional tests to recognise new wrapping div

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -95,7 +95,7 @@ class ApiIntegrationPageLocators(object):
 
 class LetterPreviewPageLocators(object):
     DOWNLOAD_PDF_LINK = (By.LINK_TEXT, 'Download as a PDF')
-    PDF_IMAGE = (By.XPATH, '//*[@id="content"]/div[2]/main/div/img')
+    PDF_IMAGE = (By.CSS_SELECTOR, '.letter img')
 
 
 class ApiKeysPageLocators(object):


### PR DESCRIPTION
There is no way that the functional tests should care how deeply nested beneath the `#content` element the image is. This is why XPath is a bad idea. This commit fixes the failing tests, and makes them more robust by using a CSS selector instead:

> Use this when you want to locate an element by CSS selector syntax. With this strategy, the first element with the matching CSS selector will be returned. If no element has a matching CSS selector, a NoSuchElementException will be raised.
– https://selenium-python.readthedocs.io/locating-elements.html#locating-elements-by-css-selectors