### PR TITLE
Allow adding a service when org type radios not on page

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -219,7 +219,11 @@ class AddServicePage(BasePage):
 
     def add_service(self, name):
         self.service_input = name
-        self.click_org_type_input()
+        try:
+            self.click_org_type_input()
+        except NoSuchElementException:
+            pass
+
         self.click_add_service_button()
 
     def click_add_service_button(self):


### PR DESCRIPTION
This is so we can deploy the admin change to remove them without breaking the tests. Can be cleaned up later.