### PR TITLE
Update tests for manage folder page to allow new UI

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -371,6 +371,7 @@ def test_template_folder_permissions(driver, login_seeded_user):
     # edit colleague's permissions so child folder is invisible
     team_members_page.click_edit_team_member(config['service']['email_auth_account'])
     edit_team_member_page = InviteUserPage(driver)
+    edit_team_member_page.show_folder_permission_checkboxes()
     edit_team_member_page.uncheck_folder_permission_checkbox(folder_names[1])
     edit_team_member_page.click_save()
 

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -371,7 +371,6 @@ def test_template_folder_permissions(driver, login_seeded_user):
     # edit colleague's permissions so child folder is invisible
     team_members_page.click_edit_team_member(config['service']['email_auth_account'])
     edit_team_member_page = InviteUserPage(driver)
-    edit_team_member_page.show_folder_permission_checkboxes()
     edit_team_member_page.uncheck_folder_permission_checkbox(folder_names[1])
     edit_team_member_page.click_save()
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -66,7 +66,8 @@ class InviteUserPageLocators(object):
     MANAGE_SERVICES_CHECKBOX = (By.NAME, 'manage_service')
     MANAGE_API_KEYS_CHECKBOX = (By.NAME, 'manage_api_keys')
     MANAGE_TEMPLATES_CHECKBOX = (By.NAME, 'manage_templates')
-    SEND_INVITATION_BUTTON = (By.CLASS_NAME, 'button')
+    CHOOSE_FOLDERS_BUTTON = (By.CSS_SELECTOR, '.button-secondary')
+    SEND_INVITATION_BUTTON = (By.CSS_SELECTOR, '[type=submit]')
 
 
 class ApiIntegrationPageLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -66,7 +66,7 @@ class InviteUserPageLocators(object):
     MANAGE_SERVICES_CHECKBOX = (By.NAME, 'manage_service')
     MANAGE_API_KEYS_CHECKBOX = (By.NAME, 'manage_api_keys')
     MANAGE_TEMPLATES_CHECKBOX = (By.NAME, 'manage_templates')
-    CHOOSE_FOLDERS_BUTTON = (By.CSS_SELECTOR, '.button-secondary')
+    CHOOSE_FOLDERS_BUTTON = (By.CSS_SELECTOR, 'button[aria-controls=folder_permissions]')
     SEND_INVITATION_BUTTON = (By.CSS_SELECTOR, '[type=submit]')
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -981,7 +981,7 @@ class ManageFolderPage(BasePage):
     delete_link = (By.LINK_TEXT, 'Delete this folder')
     name_input = NameInputElement()
     delete_button = (By.NAME, 'delete')
-    save_button = CommonPageLocators.CONTINUE_BUTTON
+    save_button = (By.CSS_SELECTOR, '[type=submit]')
     error_message = (By.CSS_SELECTOR, '.banner-dangerous')
 
     def set_name(self, new_name):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -633,6 +633,7 @@ class InviteUserPage(BasePage):
     manage_services_checkbox = InviteUserPageLocators.MANAGE_SERVICES_CHECKBOX
     manage_templates_checkbox = InviteUserPageLocators.MANAGE_TEMPLATES_CHECKBOX
     manage_api_keys_checkbox = InviteUserPageLocators.MANAGE_API_KEYS_CHECKBOX
+    choose_folders_button = InviteUserPageLocators.CHOOSE_FOLDERS_BUTTON
     send_invitation_button = InviteUserPageLocators.SEND_INVITATION_BUTTON
 
     def get_folder_checkbox(self, folder_name):
@@ -660,15 +661,23 @@ class InviteUserPage(BasePage):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()
 
-    def show_folder_permission_checkboxes(self, folder_name):
-        element = self.wait_for_element(InviteUserPage.choose_folders_button)
-        element.click()
-
     def uncheck_folder_permission_checkbox(self, folder_name):
+        try:
+            choose_folders_button = self.wait_for_invisible_element(InviteUserPage.choose_folders_button)
+            choose_folders_button.click()
+        except (NoSuchElementException, TimeoutException):
+            pass
+
         checkbox = self.wait_for_invisible_element(self.get_folder_checkbox(folder_name))
         self.unselect_checkbox(checkbox)
 
     def is_checkbox_checked(self, folder_name):
+        try:
+            choose_folders_button = self.wait_for_invisible_element(InviteUserPage.choose_folders_button)
+            choose_folders_button.click()
+        except (NoSuchElementException, TimeoutException):
+            pass
+
         checkbox = self.wait_for_invisible_element(self.get_folder_checkbox(folder_name))
         return checkbox.get_attribute('checked')
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -628,6 +628,7 @@ class InviteUserPage(BasePage):
 
     email_input = EmailInputElement()
     see_dashboard_check_box = InviteUserPageLocators.SEE_DASHBOARD_CHECKBOX
+    choose_folders_button = InviteUserPageLocators.CHOOSE_FOLDERS_BUTTON
     send_messages_checkbox = InviteUserPageLocators.SEND_MESSAGES_CHECKBOX
     manage_services_checkbox = InviteUserPageLocators.MANAGE_SERVICES_CHECKBOX
     manage_templates_checkbox = InviteUserPageLocators.MANAGE_TEMPLATES_CHECKBOX
@@ -657,6 +658,10 @@ class InviteUserPage(BasePage):
 
     def send_invitation(self):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
+        element.click()
+
+    def show_folder_permission_checkboxes(self, folder_name):
+        element = self.wait_for_element(InviteUserPage.choose_folders_button)
         element.click()
 
     def uncheck_folder_permission_checkbox(self, folder_name):


### PR DESCRIPTION
https://github.com/alphagov/notifications-admin/pull/2956 added another button to the page so the 'Save' button now needs a more specific locator.

These changes include checks for the elements the new UI introduces which fail silently if it isn't present. This means it works with the codebase before and after the new UI is added.