### PR TITLE
Redirect click on 'Save' button on user page

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -661,6 +661,10 @@ class InviteUserPage(BasePage):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()
 
+    # support variants of this page with a 'Save' button instead of 'Send invitation' (both use the same locator)
+    def click_save(self):
+        self.send_invitation()
+
     def uncheck_folder_permission_checkbox(self, folder_name):
         try:
             choose_folders_button = self.wait_for_invisible_element(InviteUserPage.choose_folders_button)


### PR DESCRIPTION
Meant to be part of https://github.com/alphagov/notifications-functional-tests/pull/243 but was missed from the final branch.

The existing `click_save` method fell through to the `BasePage` class, which only checked for the
'.button' class (which matches multiple elements in this page now).

Tested with the current `master` of the admin app as well as a new branch where the progressively enhanced folder permissions code is re-added. Both worked locally.