### PR TITLE
Change service name

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -39,6 +39,8 @@ from tests.pages import (
     ManageFolderPage,
     TeamMembersPage,
     InviteUserPage,
+    ChangeName,
+    ServiceSettingsPage
 )
 
 
@@ -415,6 +417,29 @@ def test_template_folder_permissions(driver, login_seeded_user):
         manage_folder_page = ManageFolderPage(driver)
         manage_folder_page.delete_folder()
         manage_folder_page.confirm_delete_folder()
+
+
+def test_change_service_name(driver, login_seeded_user):
+    new_name = "Functional Tests {}".format(uuid.uuid4())
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(config['service']['id'])
+    dashboard_page.click_settings()
+    service_settings = ServiceSettingsPage(driver)
+    old_name = service_settings.check_service_name()
+    change_name = ChangeName(driver)
+    change_name.go_to_change_service_name(config['service']['id'])
+    change_name.enter_new_name(new_name)
+    change_name.click_save()
+    change_name.enter_password(config['service']['seeded_user']['password'])
+    change_name.click_save()
+    service_settings.check_service_name(new_name)
+    # change the name back
+    change_name.go_to_change_service_name(config['service']['id'])
+    change_name.enter_new_name(old_name)
+    change_name.click_save()
+    change_name.enter_password(config['service']['seeded_user']['password'])
+    change_name.click_save()
+    service_settings.check_service_name(old_name)
 
 
 def _check_status_of_notification(page, notify_research_service_id, reference_to_check, status_to_check):

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -425,7 +425,6 @@ def test_change_service_name(driver, login_seeded_user):
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
     dashboard_page.click_settings()
     service_settings = ServiceSettingsPage(driver)
-    old_name = service_settings.check_service_name()
     change_name = ChangeName(driver)
     change_name.go_to_change_service_name(config['service']['id'])
     change_name.enter_new_name(new_name)
@@ -435,11 +434,11 @@ def test_change_service_name(driver, login_seeded_user):
     service_settings.check_service_name(new_name)
     # change the name back
     change_name.go_to_change_service_name(config['service']['id'])
-    change_name.enter_new_name(old_name)
+    change_name.enter_new_name(config['service']['name'])
     change_name.click_save()
     change_name.enter_password(config['service']['seeded_user']['password'])
     change_name.click_save()
-    service_settings.check_service_name(old_name)
+    service_settings.check_service_name(config['service']['name'])
 
 
 def _check_status_of_notification(page, notify_research_service_id, reference_to_check, status_to_check):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -29,6 +29,7 @@ class AddServicePageLocators(object):
 class NavigationLocators(object):
     SIGN_OUT_LINK = (By.LINK_TEXT, 'Sign out')
     TEMPLATES_LINK = (By.LINK_TEXT, 'Templates')
+    SETTINGS_LINK = (By.LINK_TEXT, 'Settings')
 
 
 class TemplatePageLocators(object):
@@ -116,3 +117,12 @@ class SmsSenderLocators(object):
     SMS_SENDER = (By.CLASS_NAME, 'sms-message-sender')
     SMS_RECIPIENT = (By.CLASS_NAME, 'sms-message-recipient')
     SMS_CONTENT = (By.CLASS_NAME, 'sms-message-wrapper')
+
+
+class ServiceSettingsLocators(object):
+    SERVICE_NAME = (By.XPATH, "//div[@class='navigation-service-name']")
+
+
+class ChangeNameLocators(object):
+    CHANGE_NAME_FIELD = (By.ID, 'name')
+    PASSWORD_FIELD = (By.ID, 'password')

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -29,19 +29,21 @@ from tests.pages.locators import (
     AddServicePageLocators,
     ApiIntegrationPageLocators,
     ApiKeysPageLocators,
+    ChangeNameLocators,
     CommonPageLocators,
     EditTemplatePageLocators,
     EmailReplyToLocators,
     InviteUserPageLocators,
+    LetterPreviewPageLocators,
     MainPageLocators,
     NavigationLocators,
+    ServiceSettingsLocators,
     SingleRecipientLocators,
     SmsSenderLocators,
     TemplatePageLocators,
     TeamMembersPageLocators,
     UploadCsvLocators,
     VerifyPageLocators,
-    LetterPreviewPageLocators
 )
 
 
@@ -166,6 +168,10 @@ class BasePage(object):
 
     def click_templates(self):
         element = self.wait_for_element(NavigationLocators.TEMPLATES_LINK)
+        element.click()
+
+    def click_settings(self):
+        element = self.wait_for_element(NavigationLocators.SETTINGS_LINK)
         element.click()
 
     def click_save(self):
@@ -834,6 +840,32 @@ class SendOneRecipient(BasePage):
     def click_use_my_phone_number(self):
         element = self.wait_for_element(SingleRecipientLocators.USE_MY_NUMBER)
         element.click()
+
+
+class ServiceSettingsPage(BasePage):
+    def check_service_name(self, expected_name=None):
+        name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
+        if expected_name and name.element.text == expected_name:
+            return True
+        elif expected_name and name.element.text != expected_name:
+            raise ValueError("Service name not changed succesfully")
+        else:
+            return name.element.text
+
+
+class ChangeName(BasePage):
+    def go_to_change_service_name(self, service_id):
+        url = "{}/services/{}/service-settings/name".format(self.base_url, service_id)
+        self.driver.get(url)
+
+    def enter_new_name(self, new_name):
+        element = self.wait_for_element(ChangeNameLocators.CHANGE_NAME_FIELD)
+        element.clear()
+        element.send_keys(new_name)
+
+    def enter_password(self, password):
+        element = self.wait_for_element(ChangeNameLocators.PASSWORD_FIELD)
+        element.send_keys(password)
 
 
 class EmailReplyTo(BasePage):


### PR DESCRIPTION
Test change service name flow to catch any problems with updating service model

Last time we were removing a service permission it broke our ability to update things on Service model on production for a few hours. We would like to avoid such scenario in the future, so we are introducing this test as a way to learn if such problems arise before the code is deployed.

Part of this story: https://www.pivotaltracker.com/story/show/165974490