### PR TITLE
Revert "Remove code handling organisation type radio buttons"

### DIFF
--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -34,6 +34,10 @@ class ServiceInputElement(BasePageElement):
     name = AddServicePageLocators.SERVICE_INPUT[1]
 
 
+class ServiceOrgTypeElement(BasePageElement):
+    name = AddServicePageLocators.ORG_TYPE_INPUT[1]
+
+
 class EmailInputElement(BasePageElement):
     name = CommonPageLocators.EMAIL_INPUT[1]
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -23,6 +23,7 @@ class VerifyPageLocators(object):
 
 class AddServicePageLocators(object):
     SERVICE_INPUT = (By.NAME, 'name')
+    ORG_TYPE_INPUT = (By.ID, 'organisation_type-0')
     ADD_SERVICE_BUTTON = (By.CLASS_NAME, 'button')
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -217,6 +217,7 @@ class RegistrationPage(BasePage):
 class AddServicePage(BasePage):
 
     service_input = ServiceInputElement()
+    org_type_input = AddServicePageLocators.ORG_TYPE_INPUT
     add_service_button = AddServicePageLocators.ADD_SERVICE_BUTTON
 
     def is_current(self):
@@ -224,11 +225,23 @@ class AddServicePage(BasePage):
 
     def add_service(self, name):
         self.service_input = name
+        try:
+            self.click_org_type_input()
+        except NoSuchElementException:
+            pass
+
         self.click_add_service_button()
 
     def click_add_service_button(self):
         element = self.wait_for_element(AddServicePage.add_service_button)
         element.click()
+
+    def click_org_type_input(self):
+        try:
+            element = self.wait_for_invisible_element(AddServicePage.org_type_input)
+            element.click()
+        except TimeoutException:
+            pass
 
 
 class SignInPage(BasePage):


### PR DESCRIPTION
Reverts alphagov/notifications-functional-tests#240

So that "choose organisation type" when creating a service works both on local and on preview