### PR TITLE
Make template link XPath more robust

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -434,14 +434,14 @@ def test_change_service_name(driver, login_seeded_user):
     change_name.click_save()
     change_name.enter_password(config['service']['seeded_user']['password'])
     change_name.click_save()
-    service_settings.check_service_name('Functional Test Org {}'.format(new_name))
+    service_settings.check_service_name(new_name)
     # change the name back
     change_name.go_to_change_service_name(config['service']['id'])
     change_name.enter_new_name(config['service']['name'])
     change_name.click_save()
     change_name.enter_password(config['service']['seeded_user']['password'])
     change_name.click_save()
-    service_settings.check_service_name('Functional Test Org {}'.format(config['service']['name']))
+    service_settings.check_service_name(config['service']['name'])
 
 
 def _check_status_of_notification(page, notify_research_service_id, reference_to_check, status_to_check):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -417,7 +417,7 @@ class ShowTemplatesPage(BasePage):
     def template_link_text(link_text):
         return (
             By.XPATH,
-            "//nav[contains(@id,'template-list')]//a//span[contains(text(), '{}')]".format(link_text)
+            "//nav[contains(@id,'template-list')]//a/span[contains(normalize-space(.), '{}')]".format(link_text)
         )
 
     @staticmethod


### PR DESCRIPTION
`text()` returns a nodelist. When the child is just text, this is a list of 1 element. When the child is interrupted, for example if it contains some HTML elements (or even a comment tag) it will return multiple text nodes and `contains()` only looks at the first. Using `.` instead of `text()` fixes this problem. Using `normalize-space` truncates runs of whitespace, which also makes things more robust. 

Better explanation here: https://sqa.stackexchange.com/a/36921