### PR TITLE
Remove non-Firefox compatible method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=0.11.1
 Flask-Cache==0.13.1
-requests==2.22.0
+requests==2.21.0
 beautifulsoup4>=4.5.1
 flake8==3.7.8
 pytest==4.6.2

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -81,7 +81,7 @@ class AntiStaleElement(AntiStale):
         def _click():
             # an element might be hidden underneath other elements (eg sticky nav items). To counter this, we can use
             # the scrollIntoView function to bring it to the top of the page
-            self.driver.execute_script('arguments[0].scrollIntoViewIfNeeded()', self.element)
+            self.driver.execute_script('arguments[0].scrollIntoView()', self.element)
             try:
                 self.element.click()
             except WebDriverException:


### PR DESCRIPTION
`scrollIntoViewIfNeeded` was added here https://github.com/alphagov/notifications-functional-tests/pull/230/commits/8fe86fc1410f1732be8751384b132491fad44d9a to make clicking on elements more reliable, but it is not supported by Firefox and we are going to make Firefox the default browser for running the tests.

This change needs to be deployed before Firefox is made the default driver in notifications-aws.