### PR TITLE
Pin requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=0.11.1
 Flask-Cache==0.13.1
-requests==2.22.0
+requests==2.21.0  # pyup: ignore, can't upgrade to a later version until we use Python 3.5
 beautifulsoup4>=4.5.1
 flake8==3.7.8
 pytest==4.6.2


### PR DESCRIPTION
Requests 2.22.0 does not support Python 3.4 (which we are still using).