### PR TITLE
make sure we wait for email validation in reply to flow

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -105,6 +105,7 @@ class SingleRecipientLocators(object):
 
 class EmailReplyToLocators(object):
     ADD_EMAIL_REPLY_TO_BUTTON = (By.CLASS_NAME, 'button')
+    CONTINUE_BUTTON = (By.XPATH, "//a[@class = 'button' and contains(text(),'Continue')]")
     EMAIL_ADDRESS_FIELD = (By.ID, 'email_address')
     REPLY_TO_ADDRESSES = (By.TAG_NAME, "body")
     IS_DEFAULT_CHECKBOX = (By.ID, "is_default")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -905,6 +905,10 @@ class EmailReplyTo(BasePage):
         element = self.wait_for_element(EmailReplyToLocators.ADD_EMAIL_REPLY_TO_BUTTON)
         element.click()
 
+    def click_continue_button(self, time=120):
+        element = self.wait_for_element(EmailReplyToLocators.CONTINUE_BUTTON, time=time)
+        element.click()
+
     def insert_email_reply_to_address(self, email_address):
         element = self.wait_for_element(EmailReplyToLocators.EMAIL_ADDRESS_FIELD)
         element.send_keys(email_address)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -403,7 +403,7 @@ def do_user_can_update_reply_to_email_to_service(driver):
     email_reply_to_page.insert_email_reply_to_address(email_address2)
     email_reply_to_page.click_add_email_reply_to()
 
-    email_reply_to_page.click_save(time=120)
+    email_reply_to_page.click_continue_button(time=120)
 
     body = email_reply_to_page.get_reply_to_email_addresses()
 


### PR DESCRIPTION
click_save checks for a button using `(By.CLASS_NAME, 'button')`. My suspicion is that the email validation holding page hasn't loaded, and selenium grabs the previous "add" button on the actual input form page. It then clicks that button a second time (thinking it's already sat through validation and then hit the continue button), and then moves straight on to checking what the page is.

By moving from the generic click_save to an xpath that specifies the button text to expect, we should solve this by not double-clicking the add button.