### PR TITLE
New Dockerfile that will be used by the concourse build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 ADD tests/ tests/
 ADD config.py config.py
+ADD scripts/ scripts/
 RUN mkdir logs
 ENTRYPOINT bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM joyzoursky/python-chromedriver:3.7
+
+WORKDIR /var/project
+ADD requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+ADD tests/ tests/
+ADD config.py config.py
+RUN mkdir logs
+ENTRYPOINT bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM joyzoursky/python-chromedriver:3.7
+FROM joyzoursky/python-chromedriver:3.7-selenium
 
 WORKDIR /var/project
 ADD requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 ADD tests/ tests/
 ADD config.py config.py
+ADD .flake8 .flake8
 ADD scripts/ scripts/
 RUN mkdir logs
 ENTRYPOINT bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def _driver():
         options = webdriver.chrome.options.Options()
         service_args = ['--verbose']
         options.add_argument("--no-sandbox")
+        options.add_argument("--headless")
         options.add_argument("user-agent=Selenium")
 
         if http_proxy is not None and http_proxy != "":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def _driver():
         driver = webdriver.Chrome(service_log_path='./logs/chrome_browser.log',
                                   service_args=service_args,
                                   options=options)
+        driver.set_window_size(1280, 720)
 
     elif driver_name == 'phantomjs':
 


### PR DESCRIPTION
The new Dockerfile is much more condensed and doesn't need alot of the extra stuff the other Dockerfile and build uses.
Once we are migrated to concourse we can remove the existing Docker folder plus Makefile.

We also a headless option for the chrome driver. The tests don't pass on concourse without it and seem to still pass on Jenkins. Documentation is a little spare around the headless mode (https://www.chromestatus.com/features/5678767817097216), however I can't see any immediate downsides of running our tests in it.

Concourse success - https://cd.gds-reliability.engineering/teams/notify/pipelines/notify/jobs/functional-tests-preview/builds/132


## Without setting the window size
![image](https://user-images.githubusercontent.com/7228605/68415124-8fa00e00-0189-11ea-8efb-fae03ae8ab70.png)

## With setting the window size
![image](https://user-images.githubusercontent.com/7228605/68415116-8c0c8700-0189-11ea-87de-4c25efd41f4a.png)


