### PR TITLE
Remove space character from screenshot filenames

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,8 @@ def driver(_driver, request):
     yield _driver
     if prev_failed_tests != request.session.testsfailed:
         print('URL at time of failure:', _driver.current_url)
-        filename = str(Path.cwd() / 'screenshots' / '{}_{}.png'.format(datetime.utcnow(), request.function.__name__))
+        filename_datetime = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        filename = str(Path.cwd() / 'screenshots' / '{}_{}.png'.format(filename_datetime, request.function.__name__))
         _driver.save_screenshot(str(filename))
         print('Error screenshot saved to ' + filename)
 


### PR DESCRIPTION
Higher risk of other things breaking if the file has a space in the
name, for example I think it may be breaking the s3-resource for
concourse so this commit should look to confirm that.

By running this branch on Concourse, I can confirm it fixes the error as seen 

Broken: https://cd.gds-reliability.engineering/teams/notify/pipelines/notify/jobs/functional-tests-preview/builds/139

Fixed: https://cd.gds-reliability.engineering/teams/notify/pipelines/notify/jobs/functional-tests-preview/builds/142