### PR TITLE
Update Python to 3.7 when running in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-slim-jessie
+FROM joyzoursky/python-chromedriver:3.7-selenium
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -21,34 +21,7 @@ RUN \
 		build-essential \
 		xvfb \
 		unzip \
-		x11-utils \
-		nodejs \
-		npm \
-	&& ln -s /usr/bin/nodejs /usr/bin/node \
-	&& npm -g install phantomjs-prebuilt@2.1.15
-
-ADD mozilla.gpg /tmp/mozilla.gpg
-RUN \
-	echo "Installing firefox" \
-	&& echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list \
-	&& apt-key add /tmp/mozilla.gpg \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		firefox-esr
-
-ADD chrome.pub /tmp/chrome.pub
-RUN echo "Installing chromedriver" \
-	&& apt-key add /tmp/chrome.pub \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		google-chrome-stable \
-	&& LATEST=$(curl -x "$HTTP_PROXY" -sSL http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
-	&& curl -x "$HTTP_PROXY" -sSLO http://chromedriver.storage.googleapis.com/$LATEST/chromedriver_linux64.zip \
-	&& unzip chromedriver_linux64.zip -d /opt/ \
-	&& ln -fs /opt/chromedriver /usr/local/bin/chromedriver \
-	&& rm chromedriver_linux64.zip \
-	&& echo "Clean up" \
-	&& rm -rf /var/lib/apt/lists/* /tmp/*
+		x11-utils
 
 RUN \
 	echo "Install pip packages" \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,19 +64,6 @@ def _driver():
                                   options=options)
         driver.set_window_size(1280, 720)
 
-    elif driver_name == 'phantomjs':
-
-        service_args = None
-
-        if http_proxy is not None and http_proxy != "":
-            service_args = [
-                '--proxy={}'.format(http_proxy)
-            ]
-
-        driver = webdriver.PhantomJS(service_args=service_args,
-                                     service_log_path='./logs/phantomjs.log')
-        driver.maximize_window()
-
     else:
         raise ValueError('Invalid Selenium driver', driver_name)
 


### PR DESCRIPTION
We can’t upgrade to the newest version of Pytest while we’re running on Python 3.4. We’ll be running on Python 3.7 once we move to Concourse, which uses the other Dockerfile.