### PR TITLE
Update locator for API page

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -74,7 +74,7 @@ class InviteUserPageLocators(object):
 
 class ApiIntegrationPageLocators(object):
     MESSAGE_LOG = (By.CSS_SELECTOR, 'div.api-notifications > details:nth-child(1)')
-    CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item-recipient')
+    CLIENT_REFERENCE = (By.CSS_SELECTOR, '.govuk-details__summary-text')
     MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item-data-item')
     VIEW_LETTER_LINK = (By.LINK_TEXT, 'View letter')
 


### PR DESCRIPTION
The HTML for an notification sent by API changed
when the `<details>` tag was moved to use the
GOV.UK Frontend component.

https://github.com/alphagov/notifications-admin/pull/3209/files#diff-a30972e77e107c6acc0ff7bf9a8ea231L53