### PR TITLE
Update locators for API page listings

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -74,8 +74,8 @@ class InviteUserPageLocators(object):
 
 class ApiIntegrationPageLocators(object):
     MESSAGE_LOG = (By.CSS_SELECTOR, 'div.api-notifications > details:nth-child(1)')
-    CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item-recipient')
-    MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item-data-item')
+    CLIENT_REFERENCE = (By.CSS_SELECTOR, '.govuk-details__summary-text')
+    MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     VIEW_LETTER_LINK = (By.LINK_TEXT, 'View letter')
 
 


### PR DESCRIPTION
More fixes for tests broken by changes from https://github.com/alphagov/notifications-admin/pull/3225/files (which changed how we include the `<details>` component.