### PR TITLE
Add a marker for tests to be run by the template-preview build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ ADD tests/ tests/
 ADD config.py config.py
 ADD .flake8 .flake8
 ADD scripts/ scripts/
+ADD pytest.ini pytest.ini
 RUN mkdir logs
 ENTRYPOINT bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    template_preview: mark a tests to run for template-preview builds.

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -47,7 +47,7 @@ from tests.pages import (
 
 
 @recordtime
-@pytest.mark.parametrize('message_type', ['sms', 'email', 'letter'])
+@pytest.mark.parametrize('message_type', ['sms', 'email', pytest.param('letter', marks=pytest.mark.template_preview)])
 def test_send_csv(driver, login_seeded_user, seeded_client, seeded_client_using_test_key, message_type):
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config['service']['id'])
@@ -177,6 +177,7 @@ def test_send_sms_with_placeholders_to_one_recipient(
     delete_template(driver, template_name)
 
 
+@pytest.mark.template_preview
 def test_view_precompiled_letter_message_log_delivered(
         driver,
         login_seeded_user,
@@ -206,6 +207,7 @@ def test_view_precompiled_letter_message_log_delivered(
     assert ref_link in link
 
 
+@pytest.mark.template_preview
 def test_view_precompiled_letter_preview_delivered(
         driver,
         login_seeded_user,


### PR DESCRIPTION
This way we don't need to list each test in the concourse pipeline.