### PR TITLE
Accept cookies before each test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 from notifications_python_client import NotificationsAPIClient
 
+from tests.pages.pages import HomePage
 from tests.pages.rollups import sign_in
 from config import config, setup_shared_config
 
@@ -68,6 +69,10 @@ def _driver():
         raise ValueError('Invalid Selenium driver', driver_name)
 
     driver.delete_all_cookies()
+
+    # go to root page and accept analytics cookies to hide banner in all pages
+    driver.get(config['notify_admin_url'])
+    HomePage(driver).accept_cookie_warning()
     yield driver
     driver.delete_all_cookies()
     driver.close()

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -6,6 +6,7 @@ class CommonPageLocators(object):
     EMAIL_INPUT = (By.NAME, 'email_address')
     PASSWORD_INPUT = (By.NAME, 'password')
     CONTINUE_BUTTON = (By.CLASS_NAME, 'button')
+    ACCEPT_COOKIE_BUTTON = (By.CLASS_NAME, 'notify-cookie-banner__button-accept')
     H1 = (By.TAG_NAME, 'H1')
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -197,6 +197,16 @@ class BasePage(object):
         return self.driver.current_url.split('/templates/')[1].split('/')[0]
 
 
+class HomePage(BasePage):
+
+    def accept_cookie_warning(self):
+        # if the cookie warning isn't present, this does nothing
+        try:
+            self.wait_for_element(CommonPageLocators.ACCEPT_COOKIE_BUTTON, time=1).click()
+        except (NoSuchElementException, TimeoutException):
+            return
+
+
 class MainPage(BasePage):
 
     set_up_account_button = MainPageLocators.SETUP_ACCOUNT_BUTTON


### PR DESCRIPTION
We want it to run before every test as cookies
are deleted at the end so consent will be lost.

This also mimics the expected user experience,
that a choice will be made when the banner is
first seen for most users.