### PR TITLE
Update selectors for GOVUK Frontend markup

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1035,12 +1035,16 @@ class DocumentDownloadLandingPage(BasePage):
     continue_button = (By.CSS_SELECTOR, 'a.govuk-button')
 
     def get_service_name(self):
-        element = self.wait_for_element((By.CSS_SELECTOR, '.govuk-body > p:first-child'))
+        element = self.wait_for_element((By.CSS_SELECTOR, 'main p:first-of-type'))
 
         return element.text.partition(' sent you ')[0]
 
     def go_to_download_page(self):
-        button = self.wait_for_element(self.continue_button)
+        try:
+            button = self.wait_for_element(self.continue_button)
+        except:
+            button = self.wait_for_element((By.CSS_SELECTOR, 'a.button'))
+
         button.click()
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1032,10 +1032,10 @@ class ConversationPage(BasePage):
 
 
 class DocumentDownloadLandingPage(BasePage):
-    continue_button = (By.CSS_SELECTOR, 'a.button')
+    continue_button = (By.CSS_SELECTOR, 'a.govuk-button')
 
     def get_service_name(self):
-        element = self.wait_for_element((By.CSS_SELECTOR, 'h1+p'))
+        element = self.wait_for_element((By.CSS_SELECTOR, '.govuk-body > p:first-child'))
 
         return element.text.partition(' sent you ')[0]
 


### PR DESCRIPTION
GOVUK Frontend was added in this pull request:

https://github.com/alphagov/document-download-frontend/pull/53

This updates the selectors for Document Download
Frontend pages so they can work with the new
markup this adds.

These changes now work before and after the changes to Document Download
Frontend.