### PR TITLE
Remove support for non-GOVUK Frontend html

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1040,10 +1040,7 @@ class DocumentDownloadLandingPage(BasePage):
         return element.text.partition(' sent you ')[0]
 
     def go_to_download_page(self):
-        try:
-            button = self.wait_for_element(self.continue_button)
-        except:
-            button = self.wait_for_element((By.CSS_SELECTOR, 'a.button'))
+        button = self.wait_for_element(self.continue_button)
 
         button.click()
 


### PR DESCRIPTION
Removes backup element selection for the document download tests.

To protect against when those pages don't use GOVUK Frontend.