### PR TITLE
make virus scan checks actually check that virus scan has run

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     template_preview: mark a tests to run for template-preview builds.
+    antivirus: mark a test to run for antivirus builds.

--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -1,3 +1,4 @@
+import pytest
 import requests
 from retry.api import retry_call
 
@@ -22,6 +23,7 @@ def upload_document(service_id, file_contents):
     return json['document']
 
 
+@pytest.mark.antivirus
 def test_document_upload_and_download(driver):
     document = retry_call(
         upload_document,

--- a/tests/functional/preview_and_dev/test_notify_api_letter.py
+++ b/tests/functional/preview_and_dev/test_notify_api_letter.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 import base64
+
+import pytest
 from retry.api import retry_call
+
 from config import config
 
 from tests.postman import (
@@ -32,6 +35,7 @@ def test_send_letter_notification_via_api(seeded_client_using_test_key):
 
 
 @recordtime
+@pytest.mark.antivirus
 def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_key):
 
     reference = config['service_name'].replace(" ", "_") + "_delivered"
@@ -44,7 +48,7 @@ def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_k
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.PENDING_VIRUS_CHECK],
+        fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.RECEIVED],
         tries=config['notification_retry_times'],
         delay=config['notification_retry_interval']
     )
@@ -53,6 +57,7 @@ def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_k
 
 
 @recordtime
+@pytest.mark.antivirus
 def test_send_precompiled_letter_with_virus_notification_via_api(seeded_client_using_test_key):
 
     # This uses a file which drops the Eicar test virus into the temp directory
@@ -68,7 +73,7 @@ def test_send_precompiled_letter_with_virus_notification_via_api(seeded_client_u
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.PENDING_VIRUS_CHECK],
+        fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.VIRUS_SCAN_FAILED],
         tries=config['notification_retry_times'],
         delay=config['notification_retry_interval']
     )

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -258,13 +258,14 @@ def test_view_precompiled_letter_preview_delivered(
     assert base64.b64encode(image_data) != preview_error
 
 
+@pytest.mark.antivirus
 def test_view_precompiled_letter_message_log_virus_scan_failed(
         driver,
         login_seeded_user,
         seeded_client_using_test_key
 ):
 
-    reference = "functional_tests_precompiled_" + str(uuid.uuid1()) + "_delivered"
+    reference = "functional_tests_precompiled_" + str(uuid.uuid1()) + "_virus_scan_failed"
 
     send_precompiled_letter_via_api(
         reference,
@@ -276,7 +277,7 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(
 
     retry_call(
         _check_status_of_notification,
-        fargs=[api_integration_page, config['service']['id'], reference, "virus-scan-failed"],
+        fargs=[api_integration_page, config['service']['id'], reference, NotificationStatuses.VIRUS_SCAN_FAILED],
         tries=config['notification_retry_times'],
         delay=config['notification_retry_interval']
     )

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -49,6 +49,8 @@ def send_notification_via_csv(upload_csv_page, message_type, seeded=False):
 
 
 def get_notification_by_id_via_api(client, notification_id, expected_statuses):
+    if isinstance(expected_statuses, str):
+        expected_statuses = set(expected_statuses)
     try:
         resp = client.get_notification_by_id(notification_id)
         notification_status = resp['status']

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -50,7 +50,7 @@ def send_notification_via_csv(upload_csv_page, message_type, seeded=False):
 
 def get_notification_by_id_via_api(client, notification_id, expected_statuses):
     if isinstance(expected_statuses, str):
-        expected_statuses = set(expected_statuses)
+        expected_statuses = {expected_statuses}
     try:
         resp = client.get_notification_by_id(notification_id)
         notification_status = resp['status']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,8 @@ default = " (default)"
 
 
 class NotificationStatuses:
-    PENDING_VIRUS_CHECK = 'pending-virus-check'
+    VIRUS_SCAN_FAILED = 'virus-scan-failed'
+    ACCEPTED = {'accepted'}
     RECEIVED = {'received'}
     DELIVERED = {'delivered', 'temporary-failure', 'permanent-failure'}
     SENT = RECEIVED | DELIVERED | {'sending', 'pending'}


### PR DESCRIPTION
do this by checking that the status of the notification goes to accepted/virus_scan_failed respectively, rather than just pending_virus_check.

also, fix a reference to refer to virus_scan rather than delivered for a bad letter to help us debug, and also mark all the tests as antivirus so that we can refer to them nicely from concourse.

Note that the antivirus mark is not an exhaustive list of every test that goes through the antivirus flow, but it at least covers a few cases and that felt like enough.