### PR TITLE
Add test for password reset flow, also get rid of redundant code

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ config = {
         'email_auth_template_id': '299726d2-dba6-42b8-8209-30e1d66ea164',
         'invitation_template_id': '4f46df42-f795-4cc4-83bb-65ca312f49cc',
         'org_invitation_template_id': '203566f0-d835-47c5-aa06-932439c86573',
+        'password_reset_template_id': '474e9242-823b-4f99-813d-ed392e7f1201',
         'registration_template_id': 'ece42649-22a8-4d06-b87f-d52d5d3f0a27',
         'verify_code_template_id': '36fb0730-6259-4da1-8a80-c8de22ad4246',
     }

--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -17,7 +17,7 @@ def test_email_auth(driver):
 
 
 @recordtime
-def test_reset_password(driver):
+def test_reset_forgotten_password(driver):
     email, password = get_email_and_password(account_type='seeded')
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
@@ -25,7 +25,7 @@ def test_reset_password(driver):
     sign_in_page.click_forgot_password_link()
 
     forgot_password_page = ForgotPasswordPage(driver)
-    assert forgot_password_page.is_page_title("Forgot your password?")
+    assert forgot_password_page.is_page_title("Forgotten your password?")
     forgot_password_page.input_email_address(email)
     forgot_password_page.click_continue()
     assert forgot_password_page.is_page_title("Check your email")

--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -1,7 +1,9 @@
 from config import config
-from tests.test_utils import recordtime
+from tests.test_utils import do_email_verification, recordtime
 
 from tests.pages.rollups import sign_in_email_auth
+from tests.pages import BasePage, ForgotPasswordPage, NewPasswordPage, SignInPage
+from tests.pages.rollups import get_email_and_password
 
 
 @recordtime
@@ -10,3 +12,32 @@ def test_email_auth(driver):
     sign_in_email_auth(driver)
     # assert url is research mode service's dashboard
     assert driver.current_url == config['notify_admin_url'] + '/services/{}'.format(config['service']['id'])
+    base_page = BasePage(driver)
+    base_page.sign_out()
+
+
+@recordtime
+def test_reset_password(driver):
+    email, password = get_email_and_password(account_type='seeded')
+    sign_in_page = SignInPage(driver)
+    sign_in_page.get()
+    assert sign_in_page.is_current()
+    sign_in_page.click_forgot_password_link()
+
+    forgot_password_page = ForgotPasswordPage(driver)
+    assert forgot_password_page.is_page_title("Forgot your password?")
+    forgot_password_page.input_email_address(email)
+    forgot_password_page.click_continue()
+    assert forgot_password_page.is_page_title("Check your email")
+
+    do_email_verification(
+        driver,
+        config['notify_templates']['password_reset_template_id'],
+        email
+    )
+    new_password_page = NewPasswordPage(driver)
+    assert new_password_page.is_page_title("Create a new password")
+    new_password_page.input_new_password(password)
+    new_password_page.click_continue()
+
+    assert new_password_page.is_page_title("Check your phone")

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -42,6 +42,10 @@ class EmailInputElement(BasePageElement):
     name = CommonPageLocators.EMAIL_INPUT[1]
 
 
+class NewPasswordInputElement(BasePageElement):
+    name = CommonPageLocators.NEW_PASSWORD_INPUT[1]
+
+
 class PasswordInputElement(BasePageElement):
     name = CommonPageLocators.PASSWORD_INPUT[1]
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -1,13 +1,14 @@
 from selenium.webdriver.support.ui import WebDriverWait
 
 from tests.pages.locators import (
-    CommonPageLocators,
-    VerifyPageLocators,
-    SignUpPageLocators,
     AddServicePageLocators,
+    ApiKeysPageLocators,
+    CommonPageLocators,
     EditTemplatePageLocators,
+    NewPasswordPageLocators,
+    SignUpPageLocators,
     UploadCsvLocators,
-    ApiKeysPageLocators
+    VerifyPageLocators,
 )
 
 
@@ -43,7 +44,7 @@ class EmailInputElement(BasePageElement):
 
 
 class NewPasswordInputElement(BasePageElement):
-    name = CommonPageLocators.NEW_PASSWORD_INPUT[1]
+    name = NewPasswordPageLocators.NEW_PASSWORD_INPUT[1]
 
 
 class PasswordInputElement(BasePageElement):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.by import By
 class CommonPageLocators(object):
     NAME_INPUT = (By.NAME, 'name')
     EMAIL_INPUT = (By.NAME, 'email_address')
+    NEW_PASSWORD_INPUT = (By.NAME, 'new_password')
     PASSWORD_INPUT = (By.NAME, 'password')
     CONTINUE_BUTTON = (By.CSS_SELECTOR, 'main button.govuk-button')
     ACCEPT_COOKIE_BUTTON = (By.CLASS_NAME, 'notify-cookie-banner__button-accept')
@@ -16,6 +17,10 @@ class MainPageLocators(object):
 
 class SignUpPageLocators(object):
     MOBILE_INPUT = (By.NAME, 'mobile_number')
+
+
+class SignInPageLocators(object):
+    FORGOT_PASSWORD_LINK = (By.LINK_TEXT, 'Forgot your password?')
 
 
 class VerifyPageLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -4,7 +4,6 @@ from selenium.webdriver.common.by import By
 class CommonPageLocators(object):
     NAME_INPUT = (By.NAME, 'name')
     EMAIL_INPUT = (By.NAME, 'email_address')
-    NEW_PASSWORD_INPUT = (By.NAME, 'new_password')
     PASSWORD_INPUT = (By.NAME, 'password')
     CONTINUE_BUTTON = (By.CSS_SELECTOR, 'main button.govuk-button')
     ACCEPT_COOKIE_BUTTON = (By.CLASS_NAME, 'notify-cookie-banner__button-accept')
@@ -20,7 +19,11 @@ class SignUpPageLocators(object):
 
 
 class SignInPageLocators(object):
-    FORGOT_PASSWORD_LINK = (By.LINK_TEXT, 'Forgot your password?')
+    FORGOT_PASSWORD_LINK = (By.LINK_TEXT, 'Forgotten your password?')
+
+
+class NewPasswordPageLocators(object):
+    NEW_PASSWORD_INPUT = (By.NAME, 'new_password')
 
 
 class VerifyPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -18,6 +18,7 @@ from tests.pages.element import (
     KeyNameInputElement,
     MobileInputElement,
     NameInputElement,
+    NewPasswordInputElement,
     PasswordInputElement,
     ServiceInputElement,
     SubjectInputElement,
@@ -38,6 +39,7 @@ from tests.pages.locators import (
     MainPageLocators,
     NavigationLocators,
     ServiceSettingsLocators,
+    SignInPageLocators,
     SingleRecipientLocators,
     SmsSenderLocators,
     TemplatePageLocators,
@@ -225,7 +227,6 @@ class RegistrationPage(BasePage):
     email_input = EmailInputElement()
     mobile_input = MobileInputElement()
     password_input = PasswordInputElement()
-    continue_button = CommonPageLocators.CONTINUE_BUTTON
 
     def is_current(self):
         return self.wait_until_url_is(self.base_url + '/register')
@@ -235,11 +236,7 @@ class RegistrationPage(BasePage):
         self.email_input = config['user']['email']
         self.mobile_input = config['user']['mobile']
         self.password_input = config['user']['password']
-        self.click_continue_button()
-
-    def click_continue_button(self):
-        element = self.wait_for_element(RegistrationPage.continue_button)
-        element.click()
+        self.click_continue()
 
 
 class AddServicePage(BasePage):
@@ -272,11 +269,25 @@ class AddServicePage(BasePage):
             pass
 
 
+class ForgotPasswordPage(BasePage):
+    email_input = EmailInputElement()
+
+    def input_email_address(self, email_address):
+        self.email_input = email_address
+
+
+class NewPasswordPage(BasePage):
+    new_password_input = NewPasswordInputElement()
+
+    def input_new_password(self, password):
+        self.new_password_input = password
+
+
 class SignInPage(BasePage):
 
     email_input = EmailInputElement()
     password_input = PasswordInputElement()
-    continue_button = CommonPageLocators.CONTINUE_BUTTON
+    forgot_password_link = SignInPageLocators.FORGOT_PASSWORD_LINK
 
     def get(self):
         self.driver.get(self.base_url + '/sign-in')
@@ -288,29 +299,24 @@ class SignInPage(BasePage):
         self.email_input = email
         self.password_input = password
 
-    def click_continue_button(self):
-        element = self.wait_for_element(SignInPage.continue_button)
+    def click_forgot_password_link(self):
+        element = self.wait_for_element(SignInPage.forgot_password_link)
         element.click()
 
     def login(self, email, password):
         self.fill_login_form(email, password)
-        self.click_continue_button()
+        self.click_continue()
 
 
 class VerifyPage(BasePage):
 
     sms_input = SmsInputElement()
-    continue_button = CommonPageLocators.CONTINUE_BUTTON
-
-    def click_continue_button(self):
-        element = self.wait_for_element(VerifyPage.continue_button)
-        element.click()
 
     def verify(self, code):
         element = self.wait_for_element(VerifyPageLocators.SMS_INPUT)
         element.clear()
         self.sms_input = code
-        self.click_continue_button()
+        self.click_continue()
 
     def has_code_error(self):
         try:
@@ -416,7 +422,6 @@ class ShowTemplatesPage(BasePage):
     email_radio = (By.CSS_SELECTOR, "input[type='radio'][value='email']")
     text_message_radio = (By.CSS_SELECTOR, "input[type='radio'][value='sms']")
     letter_radio = (By.CSS_SELECTOR, "input[type='radio'][value='letter']")
-    continue_button = (By.CSS_SELECTOR, 'main [type=submit]')
 
     add_new_folder_textbox = BasePageElement(name='add_new_folder_name')
     add_to_new_folder_textbox = BasePageElement(name='move_to_new_folder_name')
@@ -462,8 +467,7 @@ class ShowTemplatesPage(BasePage):
         radio_element = self.wait_for_invisible_element(type)
         self.select_checkbox_or_radio(radio_element)
 
-        continue_element = self.wait_for_element(self.continue_button)
-        continue_element.click()
+        self.click_continue()
 
     def select_email(self):
         self._select_template_type(self.email_radio)
@@ -493,11 +497,10 @@ class ShowTemplatesPage(BasePage):
         move_button.click()
         # wait for continue button to be displayed - sticky nav has rendered properly
         # we've seen issues
-        continue_element = self.wait_for_element(self.continue_button)
         radio_element = self.wait_for_invisible_element(self.root_template_folder_radio)
 
         self.select_checkbox_or_radio(radio_element)
-        continue_element.click()
+        self.click_continue()
 
     def get_folder_by_name(self, folder_name):
         try:
@@ -735,16 +738,11 @@ class RegisterFromInvite(BasePage):
     name_input = NameInputElement()
     mobile_input = MobileInputElement()
     password_input = PasswordInputElement()
-    continue_button = CommonPageLocators.CONTINUE_BUTTON
 
     def fill_registration_form(self, name):
         self.name_input = name
         self.mobile_input = config['user']['mobile']
         self.password_input = config['user']['password']
-
-    def click_continue(self):
-        element = self.wait_for_element(RegisterFromInvite.continue_button)
-        element.click()
 
 
 class ProfilePage(BasePage):
@@ -809,7 +807,6 @@ class ApiKeyPage(BasePage):
     key_name_input = KeyNameInputElement()
     keys_link = ApiKeysPageLocators.KEYS_PAGE_LINK
     create_key_link = ApiKeysPageLocators.CREATE_KEY_LINK
-    continue_button = CommonPageLocators.CONTINUE_BUTTON
     api_key_element = ApiKeysPageLocators.API_KEY_ELEMENT
     key_types = {
         'normal': ApiKeysPageLocators.NORMAL_KEY_RADIO,
@@ -826,10 +823,6 @@ class ApiKeyPage(BasePage):
 
     def click_create_key(self):
         element = self.wait_for_element(ApiKeyPage.create_key_link)
-        element.click()
-
-    def click_continue(self):
-        element = self.wait_for_element(ApiKeyPage.continue_button)
         element.click()
 
     def get_api_key(self):

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -19,11 +19,11 @@ def _sign_in(driver, account_type):
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
     assert sign_in_page.is_current()
-    email, password = _get_email_and_password(account_type=account_type)
+    email, password = get_email_and_password(account_type=account_type)
     sign_in_page.login(email, password)
 
 
-def _get_email_and_password(account_type):
+def get_email_and_password(account_type):
     if account_type == 'normal':
         return config['user']['email'], config['user']['password']
     elif account_type == 'seeded':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,14 +98,22 @@ def do_verify(driver):
         raise RetryException
 
 
-@retry(RetryException, tries=config['verify_code_retry_times'], delay=config['verify_code_retry_interval'])
 def do_email_auth_verify(driver):
+    do_email_verification(
+        driver,
+        config['notify_templates']['email_auth_template_id'],
+        config['service']['email_auth_account']
+    )
+
+
+@retry(RetryException, tries=config['verify_code_retry_times'], delay=config['verify_code_retry_interval'])
+def do_email_verification(driver, template_id, email_address):
     try:
-        login_link = get_link(
-            config['notify_templates']['email_auth_template_id'],
-            config['service']['email_auth_account']
+        email_link = get_link(
+            template_id,
+            email_address
         )
-        driver.get(login_link)
+        driver.get(email_link)
 
         if driver.find_element_by_class_name('heading-large').text == 'The link has expired':
             #  There was an error message (presumably we tried to use an email token that was already used/expired)


### PR DESCRIPTION
The new test test password reset flow. A positive side-effect is that it updates `email_access_validated_at` field for our seeded user.

Connected to that: should I also copy this test to staging_and_prod folder, so seeded user `email_access_validated_at` field is also updated in staging and production?