### PR TITLE
Refactor service name assertion

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -429,7 +429,7 @@ def test_change_service_name(driver, login_seeded_user):
     new_name = "Functional Tests {}".format(uuid.uuid4())
     dashboard_page = DashboardPage(driver)
     # make sure the service is actually named what we expect
-    assert dashboard_page.h2_is_service_name(config['service']['name'])
+    assert dashboard_page.get_service_name() == config['service']['name']
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
     dashboard_page.click_settings()
     service_settings = ServiceSettingsPage(driver)
@@ -442,7 +442,7 @@ def test_change_service_name(driver, login_seeded_user):
     service_settings.check_service_name(new_name)
 
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
-    assert dashboard_page.h2_is_service_name(new_name)
+    assert dashboard_page.get_service_name() == new_name
 
     # change the name back
     change_name.go_to_change_service_name(config['service']['id'])
@@ -453,7 +453,7 @@ def test_change_service_name(driver, login_seeded_user):
     service_settings.check_service_name(config['service']['name'])
 
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
-    assert dashboard_page.h2_is_service_name(config['service']['name'])
+    assert dashboard_page.get_service_name() == config['service']['name']
 
 
 def _check_status_of_notification(page, notify_research_service_id, reference_to_check, status_to_check):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -346,9 +346,9 @@ class DashboardPage(BasePage):
         expected = '{}/services/{}/dashboard'.format(self.base_url, service_id)
         return self.driver.current_url == expected
 
-    def h2_is_service_name(self, expected_name):
+    def get_service_name(self):
         element = self.wait_for_element(DashboardPage.h2)
-        return expected_name == element.text
+        return element.text
 
     def click_sms_templates(self):
         element = self.wait_for_element(DashboardPage.sms_templates_link)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,7 +150,7 @@ def do_user_registration(driver):
     service_id = dashboard_page.get_service_id()
     dashboard_page.go_to_dashboard_for_service(service_id)
 
-    assert dashboard_page.h2_is_service_name(config['service_name'])
+    assert dashboard_page.get_service_name() == config['service_name']
 
 
 def do_user_can_invite_someone_to_notify(driver, basic_view):
@@ -191,7 +191,7 @@ def do_user_can_invite_someone_to_notify(driver, basic_view):
     service_id = dashboard_page.get_service_id()
     dashboard_page.go_to_dashboard_for_service(service_id)
 
-    assert dashboard_page.h2_is_service_name(config['service_name'])
+    assert dashboard_page.get_service_name() == config['service_name']
     if basic_view:
         is_basic_view(dashboard_page)
         dashboard_page.sign_out()


### PR DESCRIPTION
To give better error logging if it fails. The current assertion only logs out the `expected_name` parameter.

Originally opened for the improved logging to help diagnose a problem with the tests. Figured this is useful anyway so raising it again.