### PR TITLE
User signs in with email on Staging and Production

### DIFF
--- a/config.py
+++ b/config.py
@@ -140,6 +140,9 @@ def setup_staging_live_config():
             'id': os.environ['SERVICE_ID'],
             'api_key': os.environ['API_KEY'],
 
+            'email_auth_account': os.environ['FUNCTIONAL_TEST_EMAIL_AUTH'],
+            'seeded_user': {'password': os.environ['FUNCTIONAL_TEST_PASSWORD']},
+
             'templates': {
                 'email': os.environ['JENKINS_BUILD_EMAIL_TEMPLATE_ID'],
                 'sms': os.environ['JENKINS_BUILD_SMS_TEMPLATE_ID'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from notifications_python_client import NotificationsAPIClient
 
 from tests.pages.pages import HomePage
-from tests.pages.rollups import sign_in
+from tests.pages.rollups import sign_in, sign_in_email_auth
 from config import config, setup_shared_config
 
 
@@ -92,7 +92,7 @@ def driver(_driver, request):
 
 @pytest.fixture(scope="module")
 def login_user(_driver):
-    sign_in(_driver)
+    sign_in_email_auth(_driver)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,7 +207,7 @@ def is_basic_view(dashboard_page):
 
 
 def is_view_for_all_permissions(page):
-    assert page.get_navigation_list() == """Dashboard\nTemplates\nUploads\nTeam members\nUsage\nSettings\nAPI integration"""
+    assert page.get_navigation_list() == "Dashboard\nTemplates\nUploads\nTeam members\nUsage\nSettings\nAPI integration"
     expected = '{}/services/{}'.format(page.base_url, page.get_service_id())
     assert page.driver.current_url == expected
 


### PR DESCRIPTION
I tried to figure out how to reverse email and sms sign in flow for functional tests in all environments, but then I came to a conclusion that this is too complex and also unnecessary (since Password Reset flow test already updates the `email_access_validated_at` field for seeded user there) 

So I just created new test users for staging and production, who are the same as the old test users when it comes to permissions etc., but they sign in with email_auth, so their `email_access_validated_at` field will not cause us trouble.

### How to test? 
- Download staging functional tests credentials and source them in your functional tests repo
- Run functional tests and see if they pass
- Delete the credentials
- Do the same for production


This Credentials PR needs to be merged in first: https://github.com/alphagov/notifications-credentials/pull/156