### PR TITLE
Letter smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test-notify-api-email: venv ## Run notify-api email tests
 test-notify-api-sms: venv ## Run notify-api sms tests
 	su -c '/var/project/scripts/run_test_script.sh /var/project/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py' hostuser
 
+.PHONY: test-notify-api-letter
+test-notify-api-letter: venv ## Run notify-api letter tests
+	su -c '/var/project/scripts/run_test_script.sh /var/project/tests/functional/staging_and_prod/notify_api/test_notify_api_letter.py' hostuser
+
 .PHONY: test-provider-email-delivery
 test-provider-email-delivery: venv ## Run provider delivery email tests
 	su -c '/var/project/scripts/run_test_script.sh /var/project/tests/provider_delivery/test_provider_delivery_email.py' hostuser

--- a/README.md
+++ b/README.md
@@ -1,74 +1,54 @@
 # notifications-functional-tests
-Functional tests for Notification applications
 
-# Running the tests
+The tests are:
+ 
+- Selenium web driver tests of the Notify user interface
+- tests of the API using the [python API client](https://github.com/alphagov/notifications-python-client).
 
-## On a local dev machine
+## Running the tests from your local dev machine
 
-The majority of tests that are used in local development and also run on master build on Jenkins (running against preview environment) are Selenium web driver tests.
+```shell
+brew cask install chromedriver # needs to be >= v2.32
+```
 
-There is an order dependency in the main tests. The registration test must run before any of the other tests as a new user account created for each test run. That user account is used for all later browser based tests. Each test run will first register a user account using the configured FUNCTIONAL_TEST_EMAIL. The email account will have random characters added so that we do not have uniqueness issues with the email address of registered user.
+To run locally you need to populate a `.gitignore` and `environment.sh` file with the relevant values.
 
-In the main suite there are also tests that that directly use the [python client](https://github.com/alphagov/notifications-python-client) for the notifications api. The client tests require an existing user, service, api key and both email and sms templates.
-
-To run locally you need to populate a `.gitignore` and `environment.sh` file with the relevant values. On Jenkins the environment variables are set in the build settings page.
-
-Note: Your local celery must be run with `ANTIVIRUS_ENABLED=1` set in the environment for the test_view_precompiled_letter_message_log_virus_scan_failed test to work
-
-## Local environment file
-
-- Make sure `Notifications Admin`, `Notifications Template Preview`, `Notifications API`, `Notifications API celery` and `Document Download API` are running locally.
-- to run locally, `source environment_local.sh`
+- To run locally, `source environment_local.sh`
 - To run against preview, staging, or live, grab the environment files found in credentials repo in `credentials/functional-tests/{env_name}`, and save them locally to a separate file that you can source separately. `environment_staging.sh`
-
-To populate the local database run
-
-```shell
-  psql notification_api -f db_setup_fixtures.sql
-```
-
-The app uses Selenium to run web automation tests which requires ChromeDriver. Install using the following command. Chromedriver must be version 2.32 or higher to fix a bug where it fails to send the '3' character.
-
-```shell
-    brew cask install chromedriver
-```
 
 Running the tests
 
 ```shell
-    source environment_local.sh
-    # source environment_preview.sh # etc etc
-    ./scripts/run_functional_tests.sh
+source environment_local.sh
+# source environment_preview.sh # etc etc
+./scripts/run_functional_tests.sh
 ```
 
-## Tests running on Jenkins docker containers
+Note, there is an order dependency in the main tests. The registration test must run before any of the other tests as a new user account created for each test run. That user account is used for all later browser based tests. Each test run will first register a user account using the configured FUNCTIONAL_TEST_EMAIL. The email account will have random characters added so that we do not have uniqueness issues with the email address of registered user.
 
+## Running the tests against your local development environment
 
-### Preview
+Make sure `Notifications Admin`, `Notifications Template Preview`, `Notifications API`, `Notifications API celery` and `Document Download API` are running locally.
 
-The same suite as local development runs on PRs against preview environment env [https://www.notify.works](https://www.notify.works)
+Your local celery must be run with `ANTIVIRUS_ENABLED=1` set in the environment for the test_view_precompiled_letter_message_log_virus_scan_failed test to work
 
-All the relevant environment variables are setup in the build settings on Jenkins for this repo.
+To populate the local database run
 
+```shell
+psql notification_api -f db_setup_fixtures.sql
+```
 
-### Staging and Live builds
+## Tests running on Concourse
 
-To run against staging and live environments a seeded user account on each of those environments has been created. In addition a service for the user has been created as well as an email and sms template created.
+These tests are run against preview, staging and production using Concourse. We run a full set of tests on preview but only a smaller set of tests, also known as smoke tests, on staging and production.
 
-To run against those instances of Notify, additional environment variables for all of SMS_TEMPLATE_ID, EMAIL_TEMPLATE_ID and SERVICE_ID. These have already been set up on the Jenkins build using the settings page.
+The Concourse jobs are defined in our [infrastructure repo](https://github.com/alphagov/notifications-aws/blob/master/concourse/templates/functional-tests.yml.j2).
 
-The [notifications-api](https://github.com/alphagov/notifications-api) and [notifications-admin](https://github.com/alphagov/notifications-admin) merge into master
-will trigger the [notifications-functional-test](https://github.com/alphagov/notifications-functional-tests) build.
+Users with the required services and templates have already been set up for each of those environments. The details for these are found in our credentials repo. Note credentials containing the needed environment variables are prefixed 'preview', 'staging' and 'live'.
 
-Note on Jenkins environment variables are prefixed 'preview', 'staging' and 'live'
 
 ## What we want to test here and what we do not want to test here
 We do not want to test contents of the page beyond a simple check that would prove we are on the page we expect to be for example check the page title or a heading in the page.
 
-These test are not intended to be used for load testing, however, some performance tolerances could be added.
+These test are not intended to be used for load testing.
 
-Currently the test will fail if the sms is not delivered in a minute, which is too long to wait but it is unclear what a valid wait time should be.
-
-Testing headers is possible and a good idea to add to these tests.
-
-Tests should be added when new features are added to the Notifications Admin app, and ideally the local dev functional tests should be run before each PR on the Admin, and API if a code change is likely to affect the provider delivery.

--- a/config.py
+++ b/config.py
@@ -139,6 +139,7 @@ def setup_staging_live_config():
         'service': {
             'id': os.environ['SERVICE_ID'],
             'api_key': os.environ['API_KEY'],
+            'api_test_key': os.environ['API_TEST_KEY'],
 
             'email_auth_account': os.environ['FUNCTIONAL_TEST_EMAIL_AUTH'],
             'seeded_user': {'password': os.environ['FUNCTIONAL_TEST_PASSWORD']},

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_letter.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_letter.py
@@ -1,0 +1,33 @@
+from io import BytesIO
+import base64
+
+from retry.api import retry_call
+from config import config
+
+from tests.postman import (
+    send_precompiled_letter_via_api,
+    get_notification_by_id_via_api,
+)
+from tests.test_utils import recordtime, NotificationStatuses
+from tests.functional.preview_and_dev.consts import correct_letter
+
+
+@recordtime
+def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_key):
+
+    reference = config['name'].replace(" ", "_") + "_delivered"
+
+    notification_id = send_precompiled_letter_via_api(
+        reference,
+        seeded_client_using_test_key,
+        BytesIO(base64.b64decode(correct_letter))
+    )
+
+    notification = retry_call(
+        get_notification_by_id_via_api,
+        fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.RECEIVED],
+        tries=config['notification_retry_times'],
+        delay=config['notification_retry_interval']
+    )
+
+    assert reference == notification['reference']


### PR DESCRIPTION
Please review commit by commit.

It required me logging into staging and production functional test user accounts and 
- turning on letters for both services
- setting up test API keys which I have added to the creds repo in https://github.com/alphagov/notifications-credentials/pull/168

Have run successfully from my local against staging and production

![image](https://user-images.githubusercontent.com/7228605/79563937-9f5f3f00-80a5-11ea-823c-9f94198eeb6a.png)
![image](https://user-images.githubusercontent.com/7228605/79564384-74291f80-80a6-11ea-9755-42652ac0bcb5.png)
