### PR TITLE
Add a test for templated letters and remove research mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,8 +134,6 @@ def setup_staging_live_config():
 
         'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
 
-        # this is either a live service or in research mode, depending on what tests are running
-        # (provider vs functional smoke tests)
         'service': {
             'id': os.environ['SERVICE_ID'],
             'api_key': os.environ['API_KEY'],

--- a/db_setup_fixtures.sql
+++ b/db_setup_fixtures.sql
@@ -9,7 +9,7 @@ e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	Functional Tests Org	t	2019-03-25 15:04:27.
 \.
 
 COPY services (id, name, created_at, updated_at, active, message_limit, restricted, email_from, created_by_id, version, research_mode, organisation_type, prefix_sms, crown, rate_limit, contact_link, consent_to_research, volume_email, volume_letter, volume_sms, organisation_id) FROM stdin;
-34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests	2019-03-25 15:02:40.869192	2019-03-25 15:35:17.203589	t	250000	f	functional.tests	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	5	t	central	t	t	3000	e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	\N	\N	\N	\N	\N
+34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests	2019-03-25 15:02:40.869192	2019-03-25 15:35:17.203589	t	250000	f	functional.tests	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	5	f	central	t	t	3000	e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	\N	\N	\N	\N	\N
 \.
 
 COPY annual_billing (id, service_id, financial_year_start, free_sms_fragment_limit, updated_at, created_at) FROM stdin;

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -15,6 +15,7 @@ from tests.functional.preview_and_dev.consts import correct_letter, pdf_with_vir
 from tests.postman import (
     send_notification_via_csv,
     get_notification_by_id_via_api,
+    get_pdf_for_letter_via_api,
     send_precompiled_letter_via_api)
 
 from tests.test_utils import (
@@ -72,6 +73,16 @@ def test_send_csv(driver, login_seeded_user, seeded_client, seeded_client_using_
         delay=config['notification_retry_interval']
     )
     assert_notification_body(notification_id, notification)
+
+    # test the whole letter creation flow, by checking the PDF has been created
+    if message_type == 'letter':
+        retry_call(
+            get_pdf_for_letter_via_api,
+            fargs=[seeded_client, notification_id],
+            tries=config['notification_retry_times'],
+            delay=config['notification_retry_interval']
+        )
+
     dashboard_page.go_to_dashboard_for_service(service_id=config['service']['id'])
 
     dashboard_stats_after = get_dashboard_stats(dashboard_page, message_type, template_id)

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -67,7 +67,7 @@ def test_send_csv(driver, login_seeded_user, seeded_client, seeded_client_using_
         get_notification_by_id_via_api,
         fargs=[seeded_client_using_test_key if message_type == 'letter' else seeded_client,
                notification_id,
-               NotificationStatuses.RECEIVED if message_type == 'letter' else NotificationStatuses.SENT],
+               NotificationStatuses.ACCEPTED if message_type == 'letter' else NotificationStatuses.SENT],
         tries=config['notification_retry_times'],
         delay=config['notification_retry_interval']
     )

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -72,3 +72,7 @@ def get_notification_by_id_via_api(client, notification_id, expected_statuses):
             raise RetryException(message)
         else:
             raise
+
+
+def get_pdf_for_letter_via_api(client, notification_id):
+    return client.get_pdf_for_letter(notification_id)


### PR DESCRIPTION
### Stop using research mode service
We want to be able to test that templated letters get created, which is not possible in research mode, so we will turn off research mode for the functional test service.

### Add a test to see if templated letter is created
To see if a templated letter is created we check if a PDF file for it has been created in S3. It's not possible to do this by checking billable_units for the letter or something similar, because that does not get returned from notifications-api and we don't have access to the database to check.

To check if the letter is in S3 we use the client method of `get_pdf_for_letter`, which raises an exception if the letter is not found.

[Pivotal story](https://www.pivotaltracker.com/story/show/172413051)

**Not done**
I've left the name of the main functional test service as `RESEARCH_MODE...`. This could be changed, but it will need to be done in a few stages since we'd need to update credentials with the new name and it would involve devs changing their environment.sh files. I'd be keen to hear whether people think this is worth doing or not.
