### PR TITLE
Update /templates locators for new checkboxes

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -72,11 +72,11 @@ class TeamMembersPageLocators(object):
 
 
 class InviteUserPageLocators(object):
-    SEND_MESSAGES_CHECKBOX = (By.NAME, 'send_messages')
-    SEE_DASHBOARD_CHECKBOX = (By.NAME, 'view_activity')
-    MANAGE_SERVICES_CHECKBOX = (By.NAME, 'manage_service')
-    MANAGE_API_KEYS_CHECKBOX = (By.NAME, 'manage_api_keys')
-    MANAGE_TEMPLATES_CHECKBOX = (By.NAME, 'manage_templates')
+    SEND_MESSAGES_CHECKBOX = (By.CSS_SELECTOR, '[value=send_messages], [name=send_messages]')
+    SEE_DASHBOARD_CHECKBOX = (By.CSS_SELECTOR, '[value=view_activity], [name=view_activity]')
+    MANAGE_SERVICES_CHECKBOX = (By.CSS_SELECTOR, '[value=manage_service], [name=manage_service]')
+    MANAGE_API_KEYS_CHECKBOX = (By.CSS_SELECTOR, '[value=manage_api_keys], [name=manage_api_keys]')
+    MANAGE_TEMPLATES_CHECKBOX = (By.CSS_SELECTOR, '[value=manage_templates], [name=manage_templates]')
     CHOOSE_FOLDERS_BUTTON = (By.CSS_SELECTOR, 'button[aria-controls=folder_permissions]')
     SEND_INVITATION_BUTTON = (By.CSS_SELECTOR, 'main [type=submit]')
 


### PR DESCRIPTION
These selectors will match both the current HTML for template list items and the new HTML that will be introduced by https://github.com/alphagov/notifications-admin/pull/3441

Once the current ones are gone from all instances of the admin app they should be updated to only match the new ones.

Old HTML uses "name" and new HTML uses "value".