### PR TITLE
Change how API page tests find elements

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -86,6 +86,7 @@ class ApiIntegrationPageLocators(object):
     HEADING_BUTTON = (By. CSS_SELECTOR, '.api-notifications-item__heading')
     CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
+    STATUS = (By.CSS_SELECTOR, '.api-notifications-item__data-value:last-of-type')
     VIEW_LETTER_LINK = (By.LINK_TEXT, 'View letter')
 
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -83,6 +83,7 @@ class InviteUserPageLocators(object):
 
 class ApiIntegrationPageLocators(object):
     MESSAGE_LOG = (By.CSS_SELECTOR, 'div.api-notifications > details:nth-child(1)')
+    HEADING_BUTTON = (By. CSS_SELECTOR, '.api-notifications-item__heading')
     CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     VIEW_LETTER_LINK = (By.LINK_TEXT, 'View letter')

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -759,6 +759,7 @@ class ApiIntegrationPage(BasePage):
     heading_button = ApiIntegrationPageLocators.HEADING_BUTTON
     client_reference = ApiIntegrationPageLocators.CLIENT_REFERENCE
     message_list = ApiIntegrationPageLocators.MESSAGE_LIST
+    status = ApiIntegrationPageLocators.STATUS
     view_letter_link = ApiIntegrationPageLocators.VIEW_LETTER_LINK
 
     def get_notification_id(self):
@@ -780,7 +781,7 @@ class ApiIntegrationPage(BasePage):
         self.driver.get(url)
 
     def get_status_from_message(self):
-        element = self.wait_for_elements(ApiIntegrationPage.message_list)[5]
+        element = self.wait_for_elements(ApiIntegrationPage.status)[0]
         return element.text
 
     def get_view_letter_link(self):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -756,6 +756,7 @@ class ProfilePage(BasePage):
 
 class ApiIntegrationPage(BasePage):
     message_log = ApiIntegrationPageLocators.MESSAGE_LOG
+    heading_button = ApiIntegrationPageLocators.HEADING_BUTTON
     client_reference = ApiIntegrationPageLocators.CLIENT_REFERENCE
     message_list = ApiIntegrationPageLocators.MESSAGE_LIST
     view_letter_link = ApiIntegrationPageLocators.VIEW_LETTER_LINK
@@ -769,6 +770,8 @@ class ApiIntegrationPage(BasePage):
         element.click()
 
     def get_client_reference(self):
+        button = self.wait_for_elements(ApiIntegrationPage.heading_button)[0]
+        button.click()
         element = self.wait_for_elements(ApiIntegrationPage.client_reference)[1]
         return element.text
 


### PR DESCRIPTION
There are two things with how the tests find elements on the API page which cause problems with how they run locally (assuming there is no virus scanning present):
1. they don't open the message list `<details>` tags before looking inside for elements
2. they look for the message status based on the number of fields each message displays, which can change.

This adds a few changes to fix them:

## Opening the message list `<details>` tags

I don't know how the webdriver + Firefox on preview can find an element inside a closed `<details>` tag but it does. The webdriver + Chrome on local can't so fails.

This opens the first `<details>` tag before looking for the element inside, like a user would. It doesn't effect the tests on preview and makes it work locally.

## Changing how the status of a message is found

If virus scanning doesn't happen, the 'updated_at' field isn't shown. This means if the virus scanning doesn't happen (locally) the tests can't find the status element because they look for the 6th field and there are only 5.

### Without scanning

<img width="739" alt="message_without_virus_scanning" src="https://user-images.githubusercontent.com/87140/83868386-b07e1100-a722-11ea-9532-0e3d61c3fb04.png">

### With scanning

<img width="728" alt="message_with_virus_scanning" src="https://user-images.githubusercontent.com/87140/83868397-b673f200-a722-11ea-97b8-7d300ea52853.png">

The changes instead make it look for the last field for an API call which works for both environments.