### PR TITLE
Change how 'View letter' link is checked for in precompiled letter test

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -106,6 +106,9 @@ class AntiStaleElementList(AntiStale):
 
         return AntiStaleListItem()
 
+    def __len__(self):
+        return len(self.element)
+
 
 class BasePage(object):
 
@@ -785,8 +788,10 @@ class ApiIntegrationPage(BasePage):
         return element.text
 
     def get_view_letter_link(self):
-        button = self.wait_for_elements(ApiIntegrationPage.heading_button)[1]
-        button.click()
+        buttons = self.wait_for_elements(ApiIntegrationPage.heading_button)
+        # open all message log entries
+        for index in range(len(buttons)):
+            buttons[index].click()
         link = self.wait_for_elements(ApiIntegrationPage.view_letter_link)[0]
         return link.get_attribute("href")
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -785,6 +785,8 @@ class ApiIntegrationPage(BasePage):
         return element.text
 
     def get_view_letter_link(self):
+        button = self.wait_for_elements(ApiIntegrationPage.heading_button)[1]
+        button.click()
         link = self.wait_for_elements(ApiIntegrationPage.view_letter_link)[0]
         return link.get_attribute("href")
 


### PR DESCRIPTION
This precompiled letter test contains a final assertion that the API page message log for it will not contain a 'View letter' link because it failed the virus scan:

`tests/functional/preview_and_dev/test_seeded_user.py::test_view_precompiled_letter_message_log_virus_scan_failed`

This assertion tests this by:
1. looking for the first 'View letter' link in the page
2. asserting it isn't for the message log related to the letter that failed by checking its `href`

This is also explained in https://github.com/alphagov/notifications-functional-tests/commit/a38d182b38edd8d558dc199b0e8bdb2c57cb32a5, where the assertion was added.

This works on preview because it can find all the 'View letter' links in the page, despite them being in closed `<details>` tags. This isn't the case when run locally.

This opens the second `<details>` tag so the 'View letter' link for that message log is visible. This
lets it be found locally and doesn't effect the test when run on other environments.

This came out of [work done on previous problems with tests that assert things in the API page](https://github.com/alphagov/notifications-functional-tests/pull/339) with @klssmith.