### PR TITLE
Make folders test scroll page before interactions

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -433,7 +433,7 @@ class DashboardPage(BasePage):
         return int(element.text)
 
 
-class ShowTemplatesPage(BasePage):
+class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
     add_new_template_link = (By.CSS_SELECTOR, "button[value='add-new-template']")
     add_new_folder_link = (By.CSS_SELECTOR, "button[value='add-new-folder']")
     add_to_new_folder_link = (By.CSS_SELECTOR, "button[value='move-to-new-folder']")
@@ -480,6 +480,7 @@ class ShowTemplatesPage(BasePage):
 
     def click_template_by_link_text(self, link_text):
         element = self.wait_for_element(self.template_link_text(link_text))
+        self.scrollToRevealElement(xpath=self.template_link_text(link_text)[1])
         element.click()
 
     def _select_template_type(self, type):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -199,6 +199,27 @@ class BasePage(object):
         return self.driver.current_url.split('/templates/')[1].split('/')[0]
 
 
+class PageWithStickyNavMixin:
+    def scrollToRevealElement(self, selector=None, xpath=None, stuckToBottom=True):
+        namespace = 'window.GOVUK.stickAtBottomWhenScrolling'
+        if stuckToBottom == False:
+            namespace = 'window.GOVUK.stickAtTopWhenScrolling'
+
+        if selector is not None:
+            js_str = f"if ('scrollToRevealElement' in {namespace}) {namespace}.scrollToRevealElement($('{selector}').eq(0))"
+            self.driver.execute_script(js_str)
+        elif xpath is not None:
+            js_str = f"""(function (document) {{
+                             if ('scrollToRevealElement' in {namespace}) {{
+                                 var matches = document.evaluate("{xpath}", document, null, XPathResult.ANY_TYPE, null);
+                                 if (matches) {{
+                                     {namespace}.scrollToRevealElement($(matches.iterateNext()));
+                                 }}
+                             }}
+                         }}(document));"""
+            self.driver.execute_script(js_str)
+
+
 class HomePage(BasePage):
 
     def accept_cookie_warning(self):


### PR DESCRIPTION
This pull request is an assumed fix for a problem I have experienced with the `test_template_folder_permissions` test.

## The problem this is meant to fix

https://github.com/alphagov/notifications-admin/pull/3476 failed this test because webdriver failed to click a link to a folder on the /templates page.

## My assumption

I'm assuming this happened because the link was obscured by the sticky nav.

### Webdriver can't make elements obscured by the sticky nav visible

Webdriver's built-in methods for determining an element can be interacted with do so based on its position being in the window frame or not. This is explained in the webdriver spec, as part of the section on clicking an element:

https://www.w3.org/TR/webdriver/#element-click

The problem here is that an element's position can be within the bounds of the window frame but still obscured by the sticky nav and webdriver cannot know that.

## What these changes do

This uses the JavaScript `scrollToRevealElement` method, introduced in https://github.com/alphagov/notifications-admin/pull/3465, to ensure the links are clear of the sticky nav before attempting to click them.

I can't prove my assumptions but these changes made my tests pass and only scroll the page to do so.