### PR TITLE
Make xpath for team member link work with changes

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -682,7 +682,8 @@ class TeamMembersPage(BasePage):
     edit_team_member_link = TeamMembersPageLocators.EDIT_TEAM_MEMBER_LINK
 
     def get_edit_link_for_member_name(self, email):
-        return self.wait_for_element((By.XPATH, "//h2[@title='{}']/..//a".format(email)))
+        return self.wait_for_element(
+            (By.XPATH, "//h2[@title='{}']/ancestor::div[contains(@class, 'user-list-item')]//a".format(email)))
 
     def h1_is_team_members(self):
         element = self.wait_for_element(TeamMembersPage.h1)


### PR DESCRIPTION
We changed the HTML for user-list-items in

https://github.com/alphagov/notifications-admin/pull/3605

This means the xpath that finds elements inside
the list items needs to work with this new HTML.

This changes the xpath to work with the existing
HTML and the new code.