### PR TITLE
Make send button locator work with new text

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -142,4 +142,4 @@ class ChangeNameLocators(object):
 
 
 class ViewTemplatePageLocators(object):
-    SEND_BUTTON = (By.LINK_TEXT, 'Send')
+    SEND_BUTTON = (By.PARTIAL_LINK_TEXT, 'Send')


### PR DESCRIPTION
The link text contains an extra suffix, added in:

https://github.com/alphagov/notifications-admin/pull/3593/commits/e42adecd075f563dcdf3dfcb3d0514f3a98619e4