### PR TITLE
Disable CSV upload tests temporarily

### DIFF
--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -1,3 +1,5 @@
+import pytest
+
 from retry.api import retry_call
 from config import config
 
@@ -11,7 +13,7 @@ from tests.postman import (
 from tests.test_utils import assert_notification_body, recordtime, NotificationStatuses
 
 
-@recordtime
+@pytest.mark.skip(reason="intermittent pager duty alerts due to queue backlog")
 def test_admin(driver, client, login_user):
     upload_csv_page = UploadCsvPage(driver)
     csv_sms_notification_id = send_notification_via_csv(upload_csv_page, 'sms')


### PR DESCRIPTION
When the database tasks queue builds up we get false pager duty alerts due to the time it takes for the test csv to get through to the front of the queue.