### PR TITLE
Restore implicit login test

### DIFF
--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -13,9 +13,12 @@ from tests.postman import (
 from tests.test_utils import assert_notification_body, recordtime, NotificationStatuses
 
 
-@pytest.mark.skip(reason="intermittent pager duty alerts due to queue backlog")
+@recordtime
 def test_admin(driver, client, login_user):
     upload_csv_page = UploadCsvPage(driver)
+
+    pytest.skip('intermittent pager duty alerts due to queue backlog')
+
     csv_sms_notification_id = send_notification_via_csv(upload_csv_page, 'sms')
     csv_sms_notification = retry_call(
         get_notification_by_id_via_api,


### PR DESCRIPTION
The login_user fixture and UploadCsvPage implicitly tests the admin login process so we should re-enable that and only skip testing the delivery which is delayed due to the queue backlog.