### PR TITLE
Make assertion of document download service name generic

### DIFF
--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -36,7 +36,7 @@ def test_document_upload_and_download(driver):
     driver.get(document['url'])
 
     landing_page = DocumentDownloadLandingPage(driver)
-    assert landing_page.get_service_name() == 'Functional Tests'
+    assert 'Functional Tests' in landing_page.get_service_name()
 
     landing_page.go_to_download_page()
 


### PR DESCRIPTION
We wish to run this test in production. It already runs in preview and
staging. However, it would currently fail in production because the name
of the service in production is "Functional Tests - CSV & Notify API"
whereas in preview and staging it's just called "Functional Tests". This
commit will make it pass in both.

I could make our functional tests smarter by taking it in as a variable
for the service name but I don't think it's worth this effort when I can
fix it quickly like this. Unit tests will already cover the service name
being shown and the assertion used is still pretty good here.