### PR TITLE
The test for api letter uploads needs more time before it fails.

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ config = {
     # static
     'notification_retry_times': 15,
     'notification_retry_interval': 5,
+    'letter_retry_times': 48, 
     'provider_retry_times': 12,
     'provider_retry_interval': 22,
     'verify_code_retry_times': 8,

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_letter.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_letter.py
@@ -26,7 +26,7 @@ def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_k
     notification = retry_call(
         get_notification_by_id_via_api,
         fargs=[seeded_client_using_test_key, notification_id, NotificationStatuses.RECEIVED],
-        tries=config['notification_retry_times'],
+        tries=config['letter_retry_times'],
         delay=config['notification_retry_interval']
     )
 


### PR DESCRIPTION
I've increase the number of retries to 48, which should mean it doesn't fail for 4 minutes.

We are more concerned that the letters create and santise properly than how long they take. During letter spikes in production we can get delays to letters and the test fails. 