### PR TITLE
Update locators / finding elements to account for hidden text

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -126,7 +126,7 @@ class SmsSenderLocators(object):
     SMS_SENDER_FIELD = (By.ID, 'sms_sender')
     SAVE_SMS_SENDER_BUTTON = (By.CSS_SELECTOR, 'main button.govuk-button')
     ALL_SMS_SENDERS = (By.TAG_NAME, 'main')
-    FIRST_CHANGE_LINK = (By.LINK_TEXT, 'Change')
+    FIRST_CHANGE_LINK = (By.PARTIAL_LINK_TEXT, 'Change')
     SMS_SENDER = (By.CLASS_NAME, 'sms-message-sender')
     SMS_RECIPIENT = (By.CLASS_NAME, 'sms-message-recipient')
     SMS_CONTENT = (By.CLASS_NAME, 'sms-message-wrapper')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -420,8 +420,8 @@ def do_user_can_update_reply_to_email_to_service(driver):
     assert email_address2 in body.text
 
     sub_body = body.text[body.text.index(email_address2):]  # find the index of the email address
-    # the id is the fourth entry [ 'email address, 'Change', 'id label', id' ]
-    email_reply_to_id = sub_body.split('\n')[3]
+    # the id is the fifth entry [ 'email address, 'Change', 'email address', 'id label', id' ]
+    email_reply_to_id = sub_body.split('\n')[4]
 
     email_reply_to_page.go_to_edit_email_reply_to_address(service_id, email_reply_to_id)
     email_reply_to_page.check_is_default_check_box()


### PR DESCRIPTION
alphagov/notifications-admin#3816 added hidden
text to make some pages more accessible. Hidden text was added to the
pages to change email reply-to address and SMS senders - after the
'Change' link. This PR updates the tests to account for that.