### PR TITLE
Build Docker image using make task

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+environment*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 FROM joyzoursky/python-chromedriver:3.7-selenium
 
 WORKDIR /var/project
-ADD requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-ADD tests/ tests/
-ADD config.py config.py
-ADD .flake8 .flake8
-ADD setup.cfg setup.cfg
-ADD pytest.ini pytest.ini
-ADD Makefile Makefile
-RUN mkdir logs
+COPY . .
+RUN make bootstrap
 ENTRYPOINT bash


### PR DESCRIPTION
Contributes to: https://github.com/alphagov/notifications-manuals/issues/9

This mirrors the approach we're taking in other repos [1][2], which
ensures the setup of the image is consistent with local setup.

[1]: https://github.com/alphagov/notifications-ruby-client/pull/122/commits/94858af5bbbe8ddf60ac9c544fcd96cb7f058cc3
[2]: https://github.com/alphagov/notifications-template-preview/pull/556