### PR TITLE
Test emergency alerts creation, approval and cancellation flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ These tests are run against preview, staging and production using Concourse. We 
 
 The Concourse jobs are defined in our [infrastructure repo](https://github.com/alphagov/notifications-aws/blob/master/concourse/templates/functional-tests.yml.j2).
 
+## Uses
+
+These tests are not intended to be used for load testing.
+
 ## Installation
 
 ```shell
@@ -89,12 +93,8 @@ access.agent: selenium AND _type: gorouter AND cf.app: notify-admin AND access.u
 
 To re-validate the email, use an Incognito window to sign in to Notify as the service user. As platform admin, you can snoop the 2FA code and verification link from the GOV.UK Notify service.
 
-## What we want to test here and what we do not want to test here
-
-We do not want to test contents of the page beyond a simple check that would prove we are on the page we expect to be for example check the page title or a heading in the page.
-
-These test are not intended to be used for load testing.
 
 ## Further documentation
 
-- [Updating db_setup_fixtures.sql](docs/update-db_setup_fixtures.md)
+- [Updating db_setup_fixtures](docs/update-db_setup_fixtures.md)
+- [Style guide](docs/style-guide.md)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Populate the local database with fixture data:
 psql notification_api -f db_setup_fixtures.sql
 ```
 
+Note: If you see any errors (for example a `duplicate key value violates unique constraint` line or similar), that table will not be saved but other following table inserts will still attempt. You'll need to fix the errors for that table (either in your local database or in the fixture script) and run the script again, or open `psql` and just copy-paste the lines from the script that you need.
+
 Now run the following in other tabs / windows:
 
 - If you're testing the Notify user interface:
@@ -92,3 +94,14 @@ To re-validate the email, use an Incognito window to sign in to Notify as the se
 We do not want to test contents of the page beyond a simple check that would prove we are on the page we expect to be for example check the page title or a heading in the page.
 
 These test are not intended to be used for load testing.
+
+## Updating db_setup_fixtures.sql
+
+1. Back up your local database with `pg_dump --format=t notification_api > ~/Downloads/my_local_db_backup.tar`
+2. Drop your local db with `dropdb notification_api`
+3. Run `make bootstrap` in the notifications-api repo to set up the database.
+4. Run `psql notification_api --file=db_setup_fixtures.sql` to get existing db objects from the db_setup_fixtures file.
+5. Make changes to your local that you want in the fixture. Note, you'll need to log in as one of the functional test users if you want to use the interface. You might need to tempoarily go into the database and make them a platform admin depending on what you are doing.
+6. Back up your new functional test data with `pg_dump --format=p --data-only notification_api > temp_db_setup_fixtures.sql`
+7. Compare the new fixtures file with the existing one and remove any extra rows that people won't want to re-add to their database. For example, Notify service templates, any notifications you might have sent while making the changes, etc.
+8. (Optional) revert your local to its previous state with `dropdb notification_api` then recreate with `createdb notification_api` and restore your data with `pg_restore -Ft -d notification_api < ~/Downloads/my_local_db_backup.tar`; Then apply the `temp_db_setup_fixtures.sql` you just updated (you may have to tackle quite a few errors), or open `psql` and just copy-paste the lines from the script that you need.

--- a/README.md
+++ b/README.md
@@ -95,13 +95,6 @@ We do not want to test contents of the page beyond a simple check that would pro
 
 These test are not intended to be used for load testing.
 
-## Updating db_setup_fixtures.sql
+## Further documentation
 
-1. Back up your local database with `pg_dump --format=t notification_api > ~/Downloads/my_local_db_backup.tar`
-2. Drop your local db with `dropdb notification_api`
-3. Run `make bootstrap` in the notifications-api repo to set up the database.
-4. Run `psql notification_api --file=db_setup_fixtures.sql` to get existing db objects from the db_setup_fixtures file.
-5. Make changes to your local that you want in the fixture. Note, you'll need to log in as one of the functional test users if you want to use the interface. You might need to tempoarily go into the database and make them a platform admin depending on what you are doing.
-6. Back up your new functional test data with `pg_dump --format=p --data-only notification_api > temp_db_setup_fixtures.sql`
-7. Compare the new fixtures file with the existing one and remove any extra rows that people won't want to re-add to their database. For example, Notify service templates, any notifications you might have sent while making the changes, etc.
-8. (Optional) revert your local to its previous state with `dropdb notification_api` then recreate with `createdb notification_api` and restore your data with `pg_restore -Ft -d notification_api < ~/Downloads/my_local_db_backup.tar`; Then apply the `temp_db_setup_fixtures.sql` you just updated (you may have to tackle quite a few errors), or open `psql` and just copy-paste the lines from the script that you need.
+- [Updating db_setup_fixtures.sql](docs/update-db_setup_fixtures.md)

--- a/config.py
+++ b/config.py
@@ -86,6 +86,18 @@ def setup_preview_dev_config():
 
         'notify_service_api_key': os.environ['NOTIFY_SERVICE_API_KEY'],
 
+        'broadcast_service': {
+            'id': os.environ['BROADCAST_SERVICE_ID'],
+            'broadcast_user_1': {
+                'email': os.environ['BROADCAST_USER_1_EMAIL'],
+                'password': os.environ['FUNCTIONAL_TESTS_SERVICE_EMAIL_PASSWORD'],
+            },
+            'broadcast_user_2': {
+                'email': os.environ['BROADCAST_USER_2_EMAIL'],
+                'password': os.environ['FUNCTIONAL_TESTS_SERVICE_EMAIL_PASSWORD'],
+            },
+        },
+
         'service': {
             'id': os.environ['FUNCTIONAL_TESTS_SERVICE_ID'],
             'name': os.environ['FUNCTIONAL_TESTS_SERVICE_NAME'],

--- a/config.py
+++ b/config.py
@@ -90,10 +90,12 @@ def setup_preview_dev_config():
             'id': os.environ['BROADCAST_SERVICE_ID'],
             'broadcast_user_1': {
                 'email': os.environ['BROADCAST_USER_1_EMAIL'],
+                # we are re-using seeded user's password
                 'password': os.environ['FUNCTIONAL_TESTS_SERVICE_EMAIL_PASSWORD'],
             },
             'broadcast_user_2': {
                 'email': os.environ['BROADCAST_USER_2_EMAIL'],
+                # we are re-using seeded user's password
                 'password': os.environ['FUNCTIONAL_TESTS_SERVICE_EMAIL_PASSWORD'],
             },
         },

--- a/db_setup_fixtures.sql
+++ b/db_setup_fixtures.sql
@@ -1,19 +1,23 @@
 COPY users (id, name, email_address, created_at, updated_at, _password, mobile_number, password_changed_at, logged_in_at, failed_login_count, state, platform_admin, current_session_id, auth_type, email_access_validated_at) FROM stdin;
 44c41c45-0fb4-4ce8-8c92-72734e31995c	Functional Tests	notify-tests-preview+local@digital.cabinet-office.gov.uk	2019-03-25 14:48:38.719334	2019-03-25 14:50:58.826605	$2b$10$pQIWZpetCN4qCtGX0GdSou6D6CeNU97U2TLWL2DnucKjjncVTJcw.	07700900001	2019-03-25 14:48:38.71801	2019-03-25 14:50:58.796995	0	active	f	23ca4bbf-347f-44a7-b998-142bca2fa991	sms_auth	NOW()
 0ebf8f7d-c511-498c-9762-41c4d47507ec	Functional Tests Email Auth	notify-tests-preview+local-email-auth@digital.cabinet-office.gov.uk	2019-03-25 15:12:53.939099	2019-03-25 15:45:48.148452	$2b$10$6k4SCUnF9q39Q/RasnGRXO0JaXoXRkd9x.vFLGG5Eo/8XOpgbdBQC	\N	2019-03-25 15:12:53.937723	2019-03-25 15:45:48.147457	0	active	f	a953c3c0-1edb-4852-a35e-1011bd1b6e20	email_auth	NOW()
-c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	Preview admin tests user	notify-tests-preview+local-admin-tests@digital.cabinet-office.gov.uk	2019-03-25 15:00:54.012798	2019-03-25 15:48:04.9784	$2b$10$rX7KZQG7NvsyfwqNX/eZru6w79nDXsABV6uSqsckLcwIL9T8TfHlG	07700900001	2019-03-25 15:00:54.005881	2019-03-25 15:48:04.97752	0	active	f	951ecf10-94e8-4b4d-86a9-a269477ed692	sms_auth	NOW()
+c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	Preview admin tests user	notify-tests-preview+local-admin-tests@digital.cabinet-office.gov.uk	2019-03-25 15:00:54.012798	2021-07-14 14:54:06.524471	$2b$10$rX7KZQG7NvsyfwqNX/eZru6w79nDXsABV6uSqsckLcwIL9T8TfHlG	07700900001	2019-03-25 15:00:54.005881	2021-07-14 14:33:48.331781	0	active	f	\N	sms_auth	NOW()
+0d2e9b87-9c54-448c-b549-f764231ee599	"Functional Tests - Broadcast User Create"	notify-tests-preview+local-broadcast1@digital.cabinet-office.gov.uk	2021-07-14 14:52:41.503215	2021-07-14 14:53:59.806529	$2b$10$t2gDo8ymix/7BcPHZVxdNOh8uN1kEf.9tuMAOxgV79YzTUDAC70ZC	07700900001	2021-07-14 14:52:41.496841	2021-07-14 14:53:00.204258	0	active	f	\N	sms_auth	NOW()
+1048af40-45f6-4249-a670-df72ba3352d7	Functional Tests - Broadcast User Approve	notify-tests-preview+local-broadcast2@digital.cabinet-office.gov.uk	2021-07-14 14:52:41.503215	2021-07-14 14:53:59.806529	$2b$10$t2gDo8ymix/7BcPHZVxdNOh8uN1kEf.9tuMAOxgV79YzTUDAC70ZC	07700900001	2021-07-14 14:52:41.496841	2021-07-14 14:53:00.204258	0	active	f	\N	sms_auth	NOW()
 \.
 
-COPY organisation (id, name, active, created_at, updated_at, email_branding_id, letter_branding_id, agreement_signed, agreement_signed_at, agreement_signed_by_id, agreement_signed_version, crown, organisation_type) FROM stdin;
-e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	Functional Tests Org	t	2019-03-25 15:04:27.500149	\N	\N	\N	\N	\N	\N	\N	\N	\N
+COPY organisation (id, name, active, created_at, updated_at, email_branding_id, letter_branding_id, agreement_signed, agreement_signed_at, agreement_signed_by_id, agreement_signed_version, crown, organisation_type, request_to_go_live_notes, agreement_signed_on_behalf_of_email_address, agreement_signed_on_behalf_of_name, billing_contact_email_addresses, billing_contact_names, billing_reference, notes, purchase_order_number) FROM stdin;
+e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	Functional Tests Org	t	2019-03-25 15:04:27.500149	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
 \.
 
-COPY services (id, name, created_at, updated_at, active, message_limit, restricted, email_from, created_by_id, version, research_mode, organisation_type, prefix_sms, crown, rate_limit, contact_link, consent_to_research, volume_email, volume_letter, volume_sms, organisation_id) FROM stdin;
-34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests	2019-03-25 15:02:40.869192	2019-03-25 15:35:17.203589	t	250000	f	functional.tests	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	5	f	central	t	t	3000	e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	\N	\N	\N	\N	\N
+COPY services (id, name, created_at, updated_at, active, message_limit, restricted, email_from, created_by_id, version, research_mode, organisation_type, prefix_sms, crown, rate_limit, contact_link, consent_to_research, volume_email, volume_letter, volume_sms, count_as_live, go_live_at, go_live_user_id, organisation_id, notes, billing_contact_email_addresses, billing_contact_names, billing_reference, purchase_order_number) FROM stdin;
+34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests	2019-03-25 15:02:40.869192	2019-03-25 15:35:17.203589	t	250000	f	functional.tests	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	5	f	central	t	t	3000	e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	\N	\N	\N	\N	t	\N	\N	\N	\N	\N	\N	\N	\N
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	Functional Tests Broadcast Service	2021-07-14 14:36:03.423486	2021-07-14 14:37:35.234642	t	50	f	functional.tests.broadcast.service	0d2e9b87-9c54-448c-b549-f764231ee599	2	f	central	t	\N	3000	\N	\N	\N	\N	\N	f	2021-07-14 14:37:35.122431	\N	38e4bf69-93b0-445d-acee-53ea53fe02df	\N	\N	\N	\N	\N
 \.
 
 COPY annual_billing (id, service_id, financial_year_start, free_sms_fragment_limit, updated_at, created_at) FROM stdin;
 59380e42-93dd-4586-8148-189da82e84b7	34b725f0-1f47-49bc-a9f5-aa2a84587c53	2018	250000	\N	2019-03-25 15:02:40.927107
+f1cb31a3-8f1e-4361-8def-c5789db9a64e	8e1d56fa-12a8-4d00-bed2-db47180bed0a	2021	150000	\N	2021-07-14 14:36:03.465174
 \.
 
 COPY api_keys (id, name, secret, service_id, expiry_date, created_at, created_by_id, updated_at, version, key_type) FROM stdin;
@@ -28,20 +32,20 @@ c1d8e17f-3abe-4858-913e-d88f689ca430	functional_tests_service_live_key	Ijg0NmE4O
 9e80ccb3-98fb-4b0b-84c0-40a9443e326b	functional_tests_service_test_key	ImZmYWYyZGVjLWU3ZGEtNGZiZS1iY2M3LWNlNmFkNTFlM2I1ZSI.hU8Q_AkTwYvlsdYyShU7H38Qw8U	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	2019-03-25 15:07:44.583174	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	test
 \.
 
-COPY templates (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, service_letter_contact_id, hidden, postage) FROM stdin;
-75a02fb0-177a-4d10-89f8-e28e48ede6e5	Functional Tests - CSV Email Template with Jenkins Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Email	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N
-63d41316-1c0a-415b-968b-8211a71ab7f1	Functional Tests - CSV SMS Template with Jenkins Build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N
-c3caccab-b066-4a43-8340-cae8b2887e86	Functional Tests - CSV Letter Template with Jenkins Build ID	letter	2019-03-25 15:24:40.689266	2019-03-25 15:26:51.614382	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Letter	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	2	f	normal	\N	f	second
-\.
-
-COPY templates_history (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, service_letter_contact_id, hidden, postage) FROM stdin;
-75a02fb0-177a-4d10-89f8-e28e48ede6e5	Functional Tests - CSV Email Template with Jenkins Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Email	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N
-63d41316-1c0a-415b-968b-8211a71ab7f1	Functional Tests - CSV SMS Template with Jenkins Build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N
-c3caccab-b066-4a43-8340-cae8b2887e86	Functional Tests - CSV Letter Template with Jenkins Build ID	letter	2019-03-25 15:24:40.689266	2019-03-25 15:26:51.614382	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Letter	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	2	f	normal	\N	f	second
+COPY templates_history (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, service_letter_contact_id, hidden, postage, broadcast_data) FROM stdin;
+75a02fb0-177a-4d10-89f8-e28e48ede6e5	Functional Tests - CSV Email Template with Jenkins Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Email	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N	\N
+63d41316-1c0a-415b-968b-8211a71ab7f1	Functional Tests - CSV SMS Template with Jenkins Build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N	\N
+c3caccab-b066-4a43-8340-cae8b2887e86	Functional Tests - CSV Letter Template with Jenkins Build ID	letter	2019-03-25 15:24:40.689266	2019-03-25 15:26:51.614382	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Letter	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	2	f	normal	\N	f	second	\N
 \.
 
 COPY inbound_numbers (id, number, provider, service_id, active, created_at, updated_at) FROM stdin;
 7d79137b-eb13-45f9-a5ec-8c2a27e00178	07700900500	mmg	34b725f0-1f47-49bc-a9f5-aa2a84587c53	t	2019-03-25 00:00:00	2019-03-25 15:20:26.028625
+\.
+
+COPY templates (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, service_letter_contact_id, hidden, postage, broadcast_data) FROM stdin;
+75a02fb0-177a-4d10-89f8-e28e48ede6e5	Functional Tests - CSV Email Template with Jenkins Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Email	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N	\N
+63d41316-1c0a-415b-968b-8211a71ab7f1	Functional Tests - CSV SMS Template with Jenkins Build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	normal	\N	f	\N	\N
+c3caccab-b066-4a43-8340-cae8b2887e86	Functional Tests - CSV Letter Template with Jenkins Build ID	letter	2019-03-25 15:24:40.689266	2019-03-25 15:26:51.614382	The quick brown fox jumped over the lazy dog. Jenkins build id: ((build_id)).	34b725f0-1f47-49bc-a9f5-aa2a84587c53	Functional Tests - CSV Letter	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	2	f	normal	\N	f	second	\N
 \.
 
 COPY permissions (id, service_id, user_id, permission, created_at) FROM stdin;
@@ -57,7 +61,22 @@ e02d1c3e-613a-46d0-bbbb-b3e341444cdb	34b725f0-1f47-49bc-a9f5-aa2a84587c53	0ebf8f
 852efe3e-545a-4cb5-a29e-349b76a469eb	34b725f0-1f47-49bc-a9f5-aa2a84587c53	0ebf8f7d-c511-498c-9762-41c4d47507ec	view_activity	2019-03-25 15:12:54.047802
 5127e9f1-70db-4029-a64f-0457c10ef4c2	34b725f0-1f47-49bc-a9f5-aa2a84587c53	0ebf8f7d-c511-498c-9762-41c4d47507ec	send_texts	2019-03-25 15:12:54.048362
 9ae0be89-c2bd-4702-9b56-036624801719	34b725f0-1f47-49bc-a9f5-aa2a84587c53	0ebf8f7d-c511-498c-9762-41c4d47507ec	send_emails	2019-03-25 15:12:54.048883
+57e897b2-a5e2-4e09-bd1b-fd655ea0d2a9	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b87-9c54-448c-b549-f764231ee599	create_broadcasts	2021-07-14 14:53:00.40982
+85b443b3-2d07-476f-9740-220187f12305	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b87-9c54-448c-b549-f764231ee599	manage_templates	2021-07-14 14:53:00.409842
+f2060ce7-7966-45a1-b5e1-17aedc93af18	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b87-9c54-448c-b549-f764231ee599	cancel_broadcasts	2021-07-14 14:53:00.409852
+d9488323-0ad7-4489-a69f-cf1afc4c24c2	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b87-9c54-448c-b549-f764231ee599	view_activity	2021-07-14 14:53:00.409881
+ea0ec5d2-ce6c-4499-98d7-60a94fd72800	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b87-9c54-448c-b549-f764231ee599	reject_broadcasts	2021-07-14 14:53:00.409891
+4866284f-9414-4f5a-954e-131b189d235f	8e1d56fa-12a8-4d00-bed2-db47180bed0a	1048af40-45f6-4249-a670-df72ba3352d7	cancel_broadcasts	2021-07-14 14:53:00.409852
+1b15bb85-52fc-43da-8365-4364103ffc7f	8e1d56fa-12a8-4d00-bed2-db47180bed0a	1048af40-45f6-4249-a670-df72ba3352d7	view_activity	2021-07-14 14:53:00.409881
+4be6e744-efea-4b8b-8af9-0d6c66de628b	8e1d56fa-12a8-4d00-bed2-db47180bed0a	1048af40-45f6-4249-a670-df72ba3352d7	reject_broadcasts	2021-07-14 14:53:00.409891
+307aaac1-66b0-48b1-aff1-7029be941a03	8e1d56fa-12a8-4d00-bed2-db47180bed0a	1048af40-45f6-4249-a670-df72ba3352d7	approve_broadcasts	2021-07-14 14:53:00.409891
 \.
+
+
+COPY service_broadcast_settings (service_id, channel, created_at, updated_at, provider) FROM stdin;
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	test	2021-07-14 14:37:35.103872	\N	all
+\.
+
 
 COPY service_email_reply_to (id, service_id, email_address, is_default, created_at, updated_at, archived) FROM stdin;
 9640a2c9-2438-4b27-9c1a-31bf73107422	34b725f0-1f47-49bc-a9f5-aa2a84587c53	notify-tests-preview+local-reply-to@digital.cabinet-office.gov.uk	f	2019-03-25 15:08:45.679181	2019-03-25 15:09:35.049148	f
@@ -72,11 +91,18 @@ COPY service_permissions (service_id, permission, created_at) FROM stdin;
 34b725f0-1f47-49bc-a9f5-aa2a84587c53	email_auth	2019-03-25 15:10:35.734382
 34b725f0-1f47-49bc-a9f5-aa2a84587c53	inbound_sms	2019-03-25 15:20:26.075574
 34b725f0-1f47-49bc-a9f5-aa2a84587c53	edit_folder_permissions	2019-03-25 15:35:17.196132
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	broadcast	2021-07-14 14:37:35.112856
 \.
 
 COPY service_sms_senders (id, sms_sender, service_id, is_default, inbound_number_id, created_at, updated_at, archived) FROM stdin;
 b259392d-94ad-450c-9fdc-fbfc61bf32f8	07700900500	34b725f0-1f47-49bc-a9f5-aa2a84587c53	t	7d79137b-eb13-45f9-a5ec-8c2a27e00178	2019-03-25 15:02:40.886024	2019-03-25 15:20:26.035965	f
 bdf151d6-2fd7-4c7f-96e5-4a23a373d13a	func tests	34b725f0-1f47-49bc-a9f5-aa2a84587c53	f	\N	2019-03-25 16:59:56.19595	2019-03-25 17:00:00.120434	f
+1f54be97-48f5-4a57-afdb-b548dbba477a	development	8e1d56fa-12a8-4d00-bed2-db47180bed0a	t	\N	2021-07-14 14:36:03.457803	\N	f
+\.
+
+COPY services_history (id, name, created_at, updated_at, active, message_limit, restricted, email_from, created_by_id, version, research_mode, organisation_type, prefix_sms, crown, rate_limit, contact_link, consent_to_research, volume_email, volume_letter, volume_sms, count_as_live, go_live_at, go_live_user_id, organisation_id, notes, billing_contact_email_addresses, billing_contact_names, billing_reference, purchase_order_number) FROM stdin;
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	Functional Tests Broadcast Service	2021-07-14 14:36:03.423486	\N	t	50	t	functional.tests.broadcast.service	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	f	central	t	\N	3000	\N	\N	\N	\N	\N	f	\N	\N	\N	\N	\N	\N	\N	\N
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	Functional Tests Broadcast Service	2021-07-14 14:36:03.423486	2021-07-14 14:37:35.234642	t	50	f	functional.tests.broadcast.service	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	2	f	central	t	\N	3000	\N	\N	\N	\N	\N	f	2021-07-14 14:37:35.122431	\N	38e4bf69-93b0-445d-acee-53ea53fe02df	\N	\N	\N	\N	\N
 \.
 
 COPY template_redacted (template_id, redact_personalisation, updated_at, updated_by_id) FROM stdin;
@@ -88,6 +114,8 @@ c3caccab-b066-4a43-8340-cae8b2887e86	f	2019-03-25 15:24:40.69439	c76a2961-08dc-4
 COPY user_to_service (user_id, service_id) FROM stdin;
 c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	34b725f0-1f47-49bc-a9f5-aa2a84587c53
 0ebf8f7d-c511-498c-9762-41c4d47507ec	34b725f0-1f47-49bc-a9f5-aa2a84587c53
+0d2e9b87-9c54-448c-b549-f764231ee599	8e1d56fa-12a8-4d00-bed2-db47180bed0a
+1048af40-45f6-4249-a670-df72ba3352d7	8e1d56fa-12a8-4d00-bed2-db47180bed0a
 \.
 
 COPY user_to_organisation (user_id, organisation_id) FROM stdin;

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,41 @@
+# Style guide
+
+## Granularity - or what we want to test here and what we do not want to test here
+
+We do not want to test contents of the page except to:
+- do a simple check that would prove we are on the page we expect to be for example check the page title or a heading in the page.
+- check presence or status of an object before or after an action, for example:
+
+```python
+  # reject an alert
+  prepare_alert_pages.click_element_by_link_text("Discard this alert")
+
+  # check that the alert is in the rejected alerts
+  prepare_alert_pages.click_element_by_link_text('Rejected alerts')
+  rejected_alerts_page = BasePage(driver)
+  assert rejected_alerts_page.is_text_present_on_page(template_name)
+```
+
+## Creating new classes for pages vs using BasePage
+
+### When to use BasePage:
+Use BasePage when all actions you will do on a page can be easily done using BasePage components. You can name your class instance in a way that will indicate what page the test is on, for example:
+
+```python
+prepare_alert_pages = BasePage(driver)
+  prepare_alert_pages.click_element_by_link_text("Test areas")
+
+```
+
+### When to define a new class for a page:
+Define a custom class for a page to DRY-up repetitive actions, to encapsulate complex functionality, and to give meaningful names to actions.
+
+
+## Custom locators vs.
+Use generic functions to click or select elements if possible, like so:
+
+```python
+current_alerts_page.click_element_by_link_text("New alert")
+```
+
+ and DRY it up into custom functions / custom locators if you need to use the same text / locator in multiple places.

--- a/docs/update-db_setup_fixtures.md
+++ b/docs/update-db_setup_fixtures.md
@@ -1,0 +1,26 @@
+# Updating db_setup_fixtures.sql
+
+Sometimes we need to add new fixtures to our functional tests setup. When we do that, it is good to update db_setup_fixtures.sql with those new fixtures.
+We do this work so that it's easier for new devs to set up and so we can maintain consistency across local environments.
+
+Below please find a step-by-step guide for updating db_setup_fixtures.sql:
+
+1. Back up your local database with `pg_dump --format=t notification_api > ~/Downloads/my_local_db_backup.tar`
+2. Drop your local db with `dropdb notification_api`
+3. Run `make bootstrap` in the notifications-api repo to set up the database.
+4. Run `psql notification_api --file=db_setup_fixtures.sql` to get existing db objects from the db_setup_fixtures file.
+5. Make changes to your local that you want in the fixture. Note, you'll need to log in as one of the functional test users if you want to use the interface. You might need to tempoarily go into the database and make them a platform admin depending on what you are doing.
+6. Back up your new functional test data with `pg_dump --format=p --data-only notification_api > temp_db_setup_fixtures.sql`
+7. Compare the new fixtures file with the existing one and remove any extra rows that people won't want to re-add to their database. For example, Notify service templates, any notifications you might have sent while making the changes, etc.
+8. (Optional) revert your local to its previous state with `dropdb notification_api` then recreate with `createdb notification_api` and restore your data with `pg_restore -Ft -d notification_api < ~/Downloads/my_local_db_backup.tar`; Then apply the `temp_db_setup_fixtures.sql` you just updated (you may have to tackle quite a few errors), or open `psql` and just copy-paste the lines from the script that you need.
+9. When tests using the new fixtures are ready, add the new db rows to preview environment by copying the lines you need from the db_setup_fixtures.sql, for example:
+
+```sql
+--log into preview
+--open psql session
+
+--copy a line that you need, for example:
+COPY permissions (id, service_id, user_id, permission, created_at) FROM stdin;
+307aaac1-66b0-48b1-aff1-7029be941a03	8e1d56fa-12a8-4d00-bed2-db47180bed0a	1048af40-45f6-4249-a670-df72ba3352d7	approve_broadcasts	2021-07-14 14:53:00.409891
+
+```

--- a/environment_local.sh
+++ b/environment_local.sh
@@ -28,3 +28,9 @@ export MMG_INBOUND_SMS_AUTH=testkey
 
 export DOCUMENT_DOWNLOAD_API_HOST=http://localhost:7000
 export DOCUMENT_DOWNLOAD_API_KEY=auth-token
+
+export BROADCAST_USER_1_EMAIL='notify-tests-preview+local-broadcast1@digital.cabinet-office.gov.uk'
+
+export BROADCAST_USER_2_EMAIL='notify-tests-preview+local-broadcast2@digital.cabinet-office.gov.uk'
+
+export BROADCAST_SERVICE_ID='8e1d56fa-12a8-4d00-bed2-db47180bed0a'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def login_user(_driver):
 
 @pytest.fixture(scope="module")
 def login_seeded_user(_driver):
-    sign_in(_driver, True)
+    sign_in(_driver, account_type='seeded')
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,0 +1,43 @@
+import uuid
+
+from config import config
+from tests.pages import DashboardPage
+from tests.pages.rollups import sign_in_broadcast_user
+from tests.test_utils import (
+    create_broadcast_template,
+    delete_template,
+    go_to_templates_page,
+    recordtime,
+)
+
+
+@recordtime
+def test_prepare_broadcast_with_template(
+    driver, seeded_client
+):
+    sign_in_broadcast_user(driver)
+
+    go_to_templates_page(driver, service='broadcast_service')
+    template_name = "test broadcast" + str(uuid.uuid4())
+    content = "This is a test only."
+    create_broadcast_template(driver, name=template_name, content=content)
+
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(service_id=config['broadcast_service']['id'])
+
+    delete_template(driver, template_name, service='broadcast_service')
+
+    """
+    check you're on broadcast page dashboard
+    go to templates
+    create a new broadcast template
+    click `get ready to send`
+    click `test areas`
+    click A and B
+    Check that the header is "Choose where to send this alert"
+    Check that there are 2 "area-list-item" items, and they correspond to selected areas
+    Click "Preview this alert"
+    Check that content is the content from the template and areas are selected areas
+    Click ""Submit for approval"
+    Check that you can see " {template_name} is waiting for approval" text
+    """

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -7,10 +7,7 @@ from tests.pages import (
     DashboardPage,
     ShowTemplatesPage,
 )
-from tests.pages.rollups import (
-    sign_in_broadcast_approve_user,
-    sign_in_broadcast_create_user,
-)
+from tests.pages.rollups import sign_in
 from tests.test_utils import (
     create_broadcast_template,
     delete_template,
@@ -21,9 +18,9 @@ from tests.test_utils import (
 
 @recordtime
 def test_prepare_broadcast_with_new_content(
-    driver, seeded_client
+    driver
 ):
-    sign_in_broadcast_create_user(driver)
+    sign_in(driver, account_type='broadcast_create_user')
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.click_element_by_link_text('Current alerts')
@@ -56,7 +53,7 @@ def test_prepare_broadcast_with_new_content(
 
     prepare_alert_pages.sign_out()
 
-    sign_in_broadcast_approve_user(driver)
+    sign_in(driver, account_type='broadcast_approve_user')
 
     dashboard_page.click_element_by_link_text('Current alerts')
     current_alerts_page.click_element_by_link_text(broadcast_title)
@@ -76,9 +73,9 @@ def test_prepare_broadcast_with_new_content(
 
 @recordtime
 def test_prepare_broadcast_with_template(
-    driver, seeded_client
+    driver
 ):
-    sign_in_broadcast_create_user(driver)
+    sign_in(driver, account_type='broadcast_create_user')
 
     go_to_templates_page(driver, service='broadcast_service')
     template_name = "test broadcast" + str(uuid.uuid4())

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,7 +1,13 @@
 import uuid
 
 from config import config
-from tests.pages import DashboardPage
+from tests.pages import (
+    CurrentAlertsPage,
+    DashboardPage,
+    NewAlertPage,
+    PrepareAlertsPages,
+    ShowTemplatesPage,
+)
 from tests.pages.rollups import sign_in_broadcast_user
 from tests.test_utils import (
     create_broadcast_template,
@@ -25,19 +31,32 @@ def test_prepare_broadcast_with_template(
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config['broadcast_service']['id'])
 
-    delete_template(driver, template_name, service='broadcast_service')
+    dashboard_page.click_current_alerts()
+    current_alerts_page = CurrentAlertsPage(driver)
+    current_alerts_page.is_text_present_on_page("You do not have any current alerts")
+    current_alerts_page.click_new_alert()
 
-    """
-    check you're on broadcast page dashboard
-    go to templates
-    create a new broadcast template
-    click `get ready to send`
-    click `test areas`
-    click A and B
-    Check that the header is "Choose where to send this alert"
-    Check that there are 2 "area-list-item" items, and they correspond to selected areas
-    Click "Preview this alert"
-    Check that content is the content from the template and areas are selected areas
-    Click ""Submit for approval"
-    Check that you can see " {template_name} is waiting for approval" text
-    """
+    new_alert_page = NewAlertPage(driver)
+    new_alert_page.select_use_a_template()
+
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
+
+    templates_page.click_element_by_link_text("Get ready to send")
+
+    prepare_alert_pages = PrepareAlertsPages(driver)
+    prepare_alert_pages.click_element_by_link_text("Test areas")
+    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
+    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    # here check if selected areas displayed
+    prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
+    prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    prepare_alert_pages.is_text_present_on_page("test template is waiting for approval")
+
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+
+    delete_template(driver, template_name, service='broadcast_service')

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -9,7 +9,10 @@ from tests.pages import (
     PrepareAlertsPages,
     ShowTemplatesPage,
 )
-from tests.pages.rollups import sign_in_broadcast_user
+from tests.pages.rollups import (
+    sign_in_broadcast_approve_user,
+    sign_in_broadcast_create_user,
+)
 from tests.test_utils import (
     create_broadcast_template,
     delete_template,
@@ -22,18 +25,19 @@ from tests.test_utils import (
 def test_prepare_broadcast_with_new_content(
     driver, seeded_client
 ):
-    sign_in_broadcast_user(driver)
+    sign_in_broadcast_create_user(driver)
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.click_current_alerts()
 
     current_alerts_page = CurrentAlertsPage(driver)
-    current_alerts_page.is_text_present_on_page("You do not have any current alerts")
+    broadcast_title = "test broadcast" + str(uuid.uuid4())
+
+    assert not current_alerts_page.is_text_present_on_page(broadcast_title)
     current_alerts_page.click_new_alert()
 
     new_alert_page = NewAlertPage(driver)
     new_alert_page.select_write_your_own_message()
-    broadcast_title = "test broadcast" + str(uuid.uuid4())
     broadcast_content = "This is a test of write your own message."
     broadcast_freeform_page = BroadcastFreeformPage(driver)
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
@@ -52,13 +56,30 @@ def test_prepare_broadcast_with_new_content(
     prepare_alert_pages.click_continue()  # click "Submit for approval"
     assert prepare_alert_pages.is_text_present_on_page(f"{broadcast_title} is waiting for approval")
 
-    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.sign_out()
+
+    sign_in_broadcast_approve_user(driver)
+    dashboard_page.click_current_alerts()
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")
+    current_alerts_page.click_continue()
+    assert current_alerts_page.is_text_present_on_page("Live since ")
+
+    current_alerts_page.click_element_by_link_text('Stop sending')
+    current_alerts_page.click_continue()
+    assert current_alerts_page.is_text_present_on_page('Stopped by Functional Tests - Broadcast User Approve')
+    current_alerts_page.click_past_alerts()
+    assert current_alerts_page.is_text_present_on_page(broadcast_title)
+
+    current_alerts_page.sign_out()
 
 
 @recordtime
 def test_prepare_broadcast_with_template(
     driver, seeded_client
 ):
+    sign_in_broadcast_create_user(driver)
+
     go_to_templates_page(driver, service='broadcast_service')
     template_name = "test broadcast" + str(uuid.uuid4())
     content = "This is a test only."

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -2,11 +2,9 @@ import uuid
 
 from config import config
 from tests.pages import (
+    BasePage,
     BroadcastFreeformPage,
-    CurrentAlertsPage,
     DashboardPage,
-    NewAlertPage,
-    PrepareAlertsPages,
     ShowTemplatesPage,
 )
 from tests.pages.rollups import (
@@ -28,22 +26,22 @@ def test_prepare_broadcast_with_new_content(
     sign_in_broadcast_create_user(driver)
 
     dashboard_page = DashboardPage(driver)
-    dashboard_page.click_current_alerts()
+    dashboard_page.click_element_by_link_text('Current alerts')
 
-    current_alerts_page = CurrentAlertsPage(driver)
+    current_alerts_page = BasePage(driver)
     broadcast_title = "test broadcast" + str(uuid.uuid4())
 
-    assert not current_alerts_page.is_text_present_on_page(broadcast_title)
-    current_alerts_page.click_new_alert()
+    current_alerts_page.click_element_by_link_text("New alert")
 
-    new_alert_page = NewAlertPage(driver)
-    new_alert_page.select_write_your_own_message()
-    broadcast_content = "This is a test of write your own message."
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value='freeform')
+    new_alert_page.click_continue()
+
     broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, "This is a test of write your own message.")
     broadcast_freeform_page.click_continue()
 
-    prepare_alert_pages = PrepareAlertsPages(driver)
+    prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Test areas")
     prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
     prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
@@ -59,17 +57,19 @@ def test_prepare_broadcast_with_new_content(
     prepare_alert_pages.sign_out()
 
     sign_in_broadcast_approve_user(driver)
-    dashboard_page.click_current_alerts()
+
+    dashboard_page.click_element_by_link_text('Current alerts')
     current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
     current_alerts_page.click_continue()
     assert current_alerts_page.is_text_present_on_page("Live since ")
 
     current_alerts_page.click_element_by_link_text('Stop sending')
-    current_alerts_page.click_continue()
+    current_alerts_page.click_continue()  # stop broadcasting
     assert current_alerts_page.is_text_present_on_page('Stopped by Functional Tests - Broadcast User Approve')
-    current_alerts_page.click_past_alerts()
-    assert current_alerts_page.is_text_present_on_page(broadcast_title)
+    current_alerts_page.click_element_by_link_text('Past alerts')
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.is_text_present_on_page(broadcast_title)
 
     current_alerts_page.sign_out()
 
@@ -88,20 +88,21 @@ def test_prepare_broadcast_with_template(
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config['broadcast_service']['id'])
 
-    dashboard_page.click_current_alerts()
-    current_alerts_page = CurrentAlertsPage(driver)
-    assert not current_alerts_page.is_text_present_on_page(template_name)
-    current_alerts_page.click_new_alert()
+    dashboard_page.click_element_by_link_text('Current alerts')
 
-    new_alert_page = NewAlertPage(driver)
-    new_alert_page.select_use_a_template()
+    current_alerts_page = BasePage(driver)
+    current_alerts_page.click_element_by_link_text("New alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value='template')
+    new_alert_page.click_continue()
 
     templates_page = ShowTemplatesPage(driver)
     templates_page.click_template_by_link_text(template_name)
 
     templates_page.click_element_by_link_text("Get ready to send")
 
-    prepare_alert_pages = PrepareAlertsPages(driver)
+    prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Test areas")
     prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
     prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
@@ -115,5 +116,8 @@ def test_prepare_broadcast_with_template(
     assert prepare_alert_pages.is_text_present_on_page(f"{template_name} is waiting for approval")
 
     prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.click_element_by_link_text('Rejected alerts')
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.is_text_present_on_page(template_name)
 
     delete_template(driver, template_name, service='broadcast_service')

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -2,6 +2,7 @@ import uuid
 
 from config import config
 from tests.pages import (
+    BroadcastFreeformPage,
     CurrentAlertsPage,
     DashboardPage,
     NewAlertPage,
@@ -18,11 +19,46 @@ from tests.test_utils import (
 
 
 @recordtime
-def test_prepare_broadcast_with_template(
+def test_prepare_broadcast_with_new_content(
     driver, seeded_client
 ):
     sign_in_broadcast_user(driver)
 
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.click_current_alerts()
+
+    current_alerts_page = CurrentAlertsPage(driver)
+    current_alerts_page.is_text_present_on_page("You do not have any current alerts")
+    current_alerts_page.click_new_alert()
+
+    new_alert_page = NewAlertPage(driver)
+    new_alert_page.select_write_your_own_message()
+    broadcast_title = "test broadcast" + str(uuid.uuid4())
+    broadcast_content = "This is a test of write your own message."
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = PrepareAlertsPages(driver)
+    prepare_alert_pages.click_element_by_link_text("Test areas")
+    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
+    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    # here check if selected areas displayed
+    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
+    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.is_text_present_on_page(f"{broadcast_title} is waiting for approval")
+
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+
+
+@recordtime
+def test_prepare_broadcast_with_template(
+    driver, seeded_client
+):
     go_to_templates_page(driver, service='broadcast_service')
     template_name = "test broadcast" + str(uuid.uuid4())
     content = "This is a test only."
@@ -33,7 +69,7 @@ def test_prepare_broadcast_with_template(
 
     dashboard_page.click_current_alerts()
     current_alerts_page = CurrentAlertsPage(driver)
-    current_alerts_page.is_text_present_on_page("You do not have any current alerts")
+    assert not current_alerts_page.is_text_present_on_page(template_name)
     current_alerts_page.click_new_alert()
 
     new_alert_page = NewAlertPage(driver)
@@ -51,11 +87,11 @@ def test_prepare_broadcast_with_template(
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_continue()  # click "Preview this alert"
     # here check if selected areas displayed
-    prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
-    prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
+    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
+    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
 
     prepare_alert_pages.click_continue()  # click "Submit for approval"
-    prepare_alert_pages.is_text_present_on_page("test template is waiting for approval")
+    assert prepare_alert_pages.is_text_present_on_page(f"{template_name} is waiting for approval")
 
     prepare_alert_pages.click_element_by_link_text("Discard this alert")
 

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -433,7 +433,7 @@ def test_template_folder_permissions(driver, login_seeded_user):
     show_templates_page.click_template_by_link_text(folder_names[2] + "_template")
     dashboard_page.sign_out()
     # delete everything
-    sign_in(driver, seeded=True)
+    sign_in(driver, account_type='seeded')
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
     dashboard_page.click_templates()
     show_templates_page = ShowTemplatesPage(driver)

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -40,6 +40,7 @@ class NavigationLocators(object):
     SIGN_OUT_LINK = (By.LINK_TEXT, 'Sign out')
     TEMPLATES_LINK = (By.LINK_TEXT, 'Templates')
     SETTINGS_LINK = (By.LINK_TEXT, 'Settings')
+    CURRENT_ALERTS_LINK = (By.LINK_TEXT, 'Current alerts')
 
 
 class TemplatePageLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -41,6 +41,7 @@ class NavigationLocators(object):
     TEMPLATES_LINK = (By.LINK_TEXT, 'Templates')
     SETTINGS_LINK = (By.LINK_TEXT, 'Settings')
     CURRENT_ALERTS_LINK = (By.LINK_TEXT, 'Current alerts')
+    PAST_ALERTS_LINK = (By.LINK_TEXT, 'Past alerts')
 
 
 class TemplatePageLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -40,8 +40,6 @@ class NavigationLocators(object):
     SIGN_OUT_LINK = (By.LINK_TEXT, 'Sign out')
     TEMPLATES_LINK = (By.LINK_TEXT, 'Templates')
     SETTINGS_LINK = (By.LINK_TEXT, 'Settings')
-    CURRENT_ALERTS_LINK = (By.LINK_TEXT, 'Current alerts')
-    PAST_ALERTS_LINK = (By.LINK_TEXT, 'Past alerts')
 
 
 class TemplatePageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -184,6 +184,10 @@ class BasePage(object):
         element = self.wait_for_element(NavigationLocators.CURRENT_ALERTS_LINK)
         element.click()
 
+    def click_past_alerts(self):
+        element = self.wait_for_element(NavigationLocators.PAST_ALERTS_LINK)
+        element.click()
+
     def click_settings(self):
         element = self.wait_for_element(NavigationLocators.SETTINGS_LINK)
         element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1140,6 +1140,7 @@ class CurrentAlertsPage(BasePage):
 
 class NewAlertPage(BasePage):
     from_template_radio = (By.CSS_SELECTOR, "input[type='radio'][value='template']")
+    freeform_radio = (By.CSS_SELECTOR, "input[type='radio'][value='freeform']")
 
     def _select_content_type(self, type):
         radio_element = self.wait_for_invisible_element(type)
@@ -1150,6 +1151,18 @@ class NewAlertPage(BasePage):
     def select_use_a_template(self):
         self._select_content_type(self.from_template_radio)
 
+    def select_write_your_own_message(self):
+        self._select_content_type(self.freeform_radio)
+
 
 class PrepareAlertsPages(BasePage):
     pass
+
+
+class BroadcastFreeformPage(BasePage):
+    title_input = NameInputElement()
+    content_input = TemplateContentElement()
+
+    def create_broadcast_content(self, title, content):
+        self.title_input = title
+        self.content_input = content

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -180,14 +180,6 @@ class BasePage(object):
         element = self.wait_for_element(NavigationLocators.TEMPLATES_LINK)
         element.click()
 
-    def click_current_alerts(self):
-        element = self.wait_for_element(NavigationLocators.CURRENT_ALERTS_LINK)
-        element.click()
-
-    def click_past_alerts(self):
-        element = self.wait_for_element(NavigationLocators.PAST_ALERTS_LINK)
-        element.click()
-
     def click_settings(self):
         element = self.wait_for_element(NavigationLocators.SETTINGS_LINK)
         element.click()
@@ -585,6 +577,10 @@ class EditSmsTemplatePage(BasePage):
         else:
             self.template_content_input = 'The quick brown fox jumped over the lazy dog. Jenkins job id: ((build_id))'
         self.click_save()
+
+
+class EditBroadcastTemplatePage(EditSmsTemplatePage):
+    pass
 
 
 class SendEmailTemplatePage(BasePage):
@@ -1132,35 +1128,6 @@ class ManageFolderPage(BasePage):
     def get_errors(self):
         errors = self.wait_for_element(self.error_message)
         return errors.text.strip()
-
-
-class CurrentAlertsPage(BasePage):
-    add_to_new_folder_link = (By.LINK_TEXT, "New alert")
-
-    def click_new_alert(self):
-        link = self.wait_for_element(self.add_to_new_folder_link)
-        link.click()
-
-
-class NewAlertPage(BasePage):
-    from_template_radio = (By.CSS_SELECTOR, "input[type='radio'][value='template']")
-    freeform_radio = (By.CSS_SELECTOR, "input[type='radio'][value='freeform']")
-
-    def _select_content_type(self, type):
-        radio_element = self.wait_for_invisible_element(type)
-        self.select_checkbox_or_radio(radio_element)
-
-        self.click_continue()
-
-    def select_use_a_template(self):
-        self._select_content_type(self.from_template_radio)
-
-    def select_write_your_own_message(self):
-        self._select_content_type(self.freeform_radio)
-
-
-class PrepareAlertsPages(BasePage):
-    pass
 
 
 class BroadcastFreeformPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -163,7 +163,10 @@ class BasePage(object):
             return url in self.driver.current_url
         return check_contains_url
 
-    def select_checkbox_or_radio(self, element):
+    def select_checkbox_or_radio(self, element=None, value=None):
+        if not element and value:
+            locator = (By.CSS_SELECTOR, f'[value={value}]')
+            element = self.wait_for_invisible_element(locator)
         if not element.get_attribute('checked'):
             element.click()
             assert element.get_attribute('checked')
@@ -175,6 +178,10 @@ class BasePage(object):
 
     def click_templates(self):
         element = self.wait_for_element(NavigationLocators.TEMPLATES_LINK)
+        element.click()
+
+    def click_current_alerts(self):
+        element = self.wait_for_element(NavigationLocators.CURRENT_ALERTS_LINK)
         element.click()
 
     def click_settings(self):
@@ -201,6 +208,10 @@ class BasePage(object):
         # http://localhost:6012/services/237dd966-b092-42ab-b406-0a00187d007f/templates/4808eb34-5225-492b-8af2-14b232f05b8e/edit
         # circle back and do better
         return self.driver.current_url.split('/templates/')[1].split('/')[0]
+
+    def click_element_by_link_text(self, link_text):
+        element = self.wait_for_element((By.LINK_TEXT, link_text))
+        element.click()
 
 
 class PageWithStickyNavMixin:
@@ -393,8 +404,7 @@ class DashboardPage(BasePage):
         element.click()
 
     def click_user_profile_link(self, link_text):
-        element = self.wait_for_element((By.LINK_TEXT, link_text))
-        element.click()
+        self.click_element_by_link_text(link_text)
 
     def click_api_keys_link(self):
         element = self.wait_for_element(DashboardPage.api_keys_link)
@@ -1118,3 +1128,28 @@ class ManageFolderPage(BasePage):
     def get_errors(self):
         errors = self.wait_for_element(self.error_message)
         return errors.text.strip()
+
+
+class CurrentAlertsPage(BasePage):
+    add_to_new_folder_link = (By.LINK_TEXT, "New alert")
+
+    def click_new_alert(self):
+        link = self.wait_for_element(self.add_to_new_folder_link)
+        link.click()
+
+
+class NewAlertPage(BasePage):
+    from_template_radio = (By.CSS_SELECTOR, "input[type='radio'][value='template']")
+
+    def _select_content_type(self, type):
+        radio_element = self.wait_for_invisible_element(type)
+        self.select_checkbox_or_radio(radio_element)
+
+        self.click_continue()
+
+    def select_use_a_template(self):
+        self._select_content_type(self.from_template_radio)
+
+
+class PrepareAlertsPages(BasePage):
+    pass

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -14,6 +14,16 @@ def sign_in_email_auth(driver):
     do_email_auth_verify(driver)
 
 
+def sign_in_broadcast_create_user(driver):
+    _sign_in(driver, 'broadcast_create_user')
+    do_verify(driver)
+
+
+def sign_in_broadcast_approve_user(driver):
+    _sign_in(driver, 'broadcast_approve_user')
+    do_verify(driver)
+
+
 def _sign_in(driver, account_type):
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
@@ -30,4 +40,14 @@ def get_email_and_password(account_type):
     elif account_type == 'email_auth':
         # has the same password as the seeded user
         return config['service']['email_auth_account'], config['service']['seeded_user']['password']
+    elif account_type == 'broadcast_create_user':
+        return (
+            config['broadcast_service']['broadcast_user_1']['email'],
+            config['broadcast_service']['broadcast_user_1']['password']
+        )
+    elif account_type == 'broadcast_approve_user':
+        return (
+            config['broadcast_service']['broadcast_user_2']['email'],
+            config['broadcast_service']['broadcast_user_2']['password']
+        )
     raise Exception('unknown account_type {}'.format(account_type))

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -3,8 +3,8 @@ from tests.pages import SignInPage
 from tests.test_utils import do_email_auth_verify, do_verify
 
 
-def sign_in(driver, seeded=False):
-    _sign_in(driver, 'seeded' if seeded else 'normal')
+def sign_in(driver, account_type='normal'):
+    _sign_in(driver, account_type)
     do_verify(driver)
 
 
@@ -12,16 +12,6 @@ def sign_in_email_auth(driver):
     _sign_in(driver, 'email_auth')
     assert driver.current_url == config['notify_admin_url'] + '/two-factor-email-sent'
     do_email_auth_verify(driver)
-
-
-def sign_in_broadcast_create_user(driver):
-    _sign_in(driver, 'broadcast_create_user')
-    do_verify(driver)
-
-
-def sign_in_broadcast_approve_user(driver):
-    _sign_in(driver, 'broadcast_approve_user')
-    do_verify(driver)
 
 
 def _sign_in(driver, account_type):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,19 +234,28 @@ def create_sms_template(driver, name="test template", content=None):
     return template_page.get_template_id()
 
 
-def go_to_templates_page(driver):
+def create_broadcast_template(driver, name="test template", content=None):
+    show_templates_page = ShowTemplatesPage(driver)
+    show_templates_page.click_add_new_template()
+
+    template_page = EditSmsTemplatePage(driver)
+    template_page.create_template(name=name, content=content)
+    return template_page.get_template_id()
+
+
+def go_to_templates_page(driver, service='service'):
     dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service(config['service']['id'])
+    dashboard_page.go_to_dashboard_for_service(config[service]['id'])
     dashboard_page.click_templates()
 
 
-def delete_template(driver, template_name):
+def delete_template(driver, template_name, service='service'):
     show_templates_page = ShowTemplatesPage(driver)
     try:
         show_templates_page.click_template_by_link_text(template_name)
     except TimeoutException:
         dashboard_page = DashboardPage(driver)
-        dashboard_page.go_to_dashboard_for_service(config['service']['id'])
+        dashboard_page.go_to_dashboard_for_service(config[service]['id'])
         dashboard_page.click_templates()
         show_templates_page.click_template_by_link_text(template_name)
     template_page = EditEmailTemplatePage(driver)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from config import config, generate_unique_email
 from tests.pages import (
     AddServicePage,
     DashboardPage,
+    EditBroadcastTemplatePage,
     EditEmailTemplatePage,
     EditSmsTemplatePage,
     EmailReplyTo,
@@ -238,7 +239,7 @@ def create_broadcast_template(driver, name="test template", content=None):
     show_templates_page = ShowTemplatesPage(driver)
     show_templates_page.click_add_new_template()
 
-    template_page = EditSmsTemplatePage(driver)
+    template_page = EditBroadcastTemplatePage(driver)
     template_page.create_template(name=name, content=content)
     return template_page.get_template_id()
 


### PR DESCRIPTION
### This is work of @klssmith @leohemsted  and I.

### In this PR we:
- add details for a broadcast service and 2 broadcast users - one that can create broadcasts, and one that can approve them.
- test creating a broadcast template, and then preparing an alert based on that template. This alert gets discarded
- test preparing an alert with adding own content, then 2nd user approving it, and cancelling it
- some minor refactors

### What we found to be out of scope of this PR, but would potentially like to do later:
- test sending a broadcast via API (ticket for this: https://www.pivotaltracker.com/story/show/179120842)
- do deeper testing of sending the broadcast: are provider messages created, do lambdas get called etc (ticket for this: https://www.pivotaltracker.com/n/projects/1443052/stories/178946233 )

### Considerations:
- we have not updated the credentials yet, so the tests will fail on preview until we do that.
- review commit by commit