### PR TITLE
Check that gov.uk/alerts updates dynamically when alert is published or cancelled

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,18 +42,15 @@ urls = {
     },
     'preview': {
         'api': 'https://api.notify.works',
-        'admin': 'https://www.notify.works',
-        'gov_uk_alerts': 'https://www.integration.publishing.service.gov.uk/alerts'
+        'admin': 'https://www.notify.works'
     },
     'staging': {
         'api': 'https://api.staging-notify.works',
-        'admin': 'https://www.staging-notify.works',
-        'gov_uk_alerts': 'https://www.staging.publishing.service.gov.uk/alerts'
+        'admin': 'https://www.staging-notify.works'
     },
     'live': {
         'api': 'https://api.notifications.service.gov.uk',
-        'admin': 'https://www.notifications.service.gov.uk',
-        'gov_uk_alerts': 'https://www.gov.uk/alerts'
+        'admin': 'https://www.notifications.service.gov.uk'
     }
 }
 
@@ -71,7 +68,6 @@ def setup_shared_config():
         'env': env,
         'notify_api_url': urls[env]['api'],
         'notify_admin_url': urls[env]['admin'],
-        'gov_uk_alerts_url': urls[env]['gov_uk_alerts']
     })
 
 
@@ -79,6 +75,8 @@ def setup_preview_dev_config():
     uuid_for_test_run = str(uuid.uuid4())
 
     config.update({
+        'gov_uk_alerts_url': 'https://www.integration.publishing.service.gov.uk/alerts',
+
         'service_name': 'Functional Test_{}'.format(uuid_for_test_run),
 
         'user': {

--- a/config.py
+++ b/config.py
@@ -42,15 +42,18 @@ urls = {
     },
     'preview': {
         'api': 'https://api.notify.works',
-        'admin': 'https://www.notify.works'
+        'admin': 'https://www.notify.works',
+        'gov_uk_alerts': 'https://www.integration.publishing.service.gov.uk/alerts'
     },
     'staging': {
         'api': 'https://api.staging-notify.works',
-        'admin': 'https://www.staging-notify.works'
+        'admin': 'https://www.staging-notify.works',
+        'gov_uk_alerts': 'https://www.staging.publishing.service.gov.uk/alerts'
     },
     'live': {
         'api': 'https://api.notifications.service.gov.uk',
-        'admin': 'https://www.notifications.service.gov.uk'
+        'admin': 'https://www.notifications.service.gov.uk',
+        'gov_uk_alerts': 'https://www.gov.uk/alerts'
     }
 }
 
@@ -68,6 +71,7 @@ def setup_shared_config():
         'env': env,
         'notify_api_url': urls[env]['api'],
         'notify_admin_url': urls[env]['admin'],
+        'gov_uk_alerts_url': urls[env]['gov_uk_alerts']
     })
 
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -39,14 +39,15 @@ def test_prepare_broadcast_with_new_content(
     broadcast_freeform_page.click_continue()
 
     prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Test areas")
-    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
-    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_continue()  # click "Preview this alert"
     # here check if selected areas displayed
-    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
-    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
+    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
     prepare_alert_pages.click_continue()  # click "Submit for approval"
     assert prepare_alert_pages.is_text_present_on_page(f"{broadcast_title} is waiting for approval")
@@ -100,14 +101,15 @@ def test_prepare_broadcast_with_template(
     templates_page.click_element_by_link_text("Get ready to send")
 
     prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Test areas")
-    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-a")
-    prepare_alert_pages.select_checkbox_or_radio(value="test-santa-claus-village-rovaniemi-b")
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_continue()  # click "Preview this alert"
     # here check if selected areas displayed
-    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi A")
-    assert prepare_alert_pages.is_text_present_on_page("Santa Claus Village, Rovaniemi B")
+    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
     prepare_alert_pages.click_continue()  # click "Submit for approval"
     assert prepare_alert_pages.is_text_present_on_page(f"{template_name} is waiting for approval")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -125,7 +125,8 @@ class BasePage(object):
         else:
             self.driver.get(self.base_url)
 
-    def get_current_url(self):
+    @property
+    def current_url(self):
         return self.driver.current_url
 
     def wait_for_invisible_element(self, locator):
@@ -1143,3 +1144,23 @@ class BroadcastFreeformPage(BasePage):
     def create_broadcast_content(self, title, content):
         self.title_input = title
         self.content_input = content
+
+
+class GovUkAlertsPage(BasePage):
+    def __init__(self, driver):
+        self.gov_uk_alerts_url = config['gov_uk_alerts_url']
+        self.driver = driver
+
+    def get(self):
+        self.driver.get(self.gov_uk_alerts_url)
+
+    def check_alert_is_published(self, page_title, broadcast_content):
+        locator = (By.XPATH, "//p[text() = '{}']".format(broadcast_content))
+        for x in range(6):
+            try:
+                self.wait_for_invisible_element(locator)
+                assert self.is_text_present_on_page(broadcast_content)
+                return
+            except TimeoutException:
+                self.click_element_by_link_text(page_title)  # refresh page
+        raise TimeoutException  # if alert not present after this time, raise exception

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -119,6 +119,15 @@ class BasePage(object):
         self.base_url = config['notify_admin_url']
         self.driver = driver
 
+    def get(self, url=None):
+        if url:
+            self.driver.get(url)
+        else:
+            self.driver.get(self.base_url)
+
+    def get_current_url(self):
+        return self.driver.current_url
+
     def wait_for_invisible_element(self, locator):
         return AntiStaleElement(
             self.driver,
@@ -245,9 +254,6 @@ class HomePage(BasePage):
 class MainPage(BasePage):
 
     set_up_account_button = MainPageLocators.SETUP_ACCOUNT_BUTTON
-
-    def get(self):
-        self.driver.get(self.base_url)
 
     def click_set_up_account(self):
         element = self.wait_for_element(MainPage.set_up_account_button)


### PR DESCRIPTION
Test that alert gets published in "Current alerts" tab when it starts broadcasting, and that it is moved to "Past alerts" tab when we cancel it.

Tested against Preview environment.

Pivotal ticket: https://www.pivotaltracker.com/story/show/180099555