### PR TITLE
Remove ‘enter password’ step when changing service name

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -466,8 +466,6 @@ def test_change_service_name(driver, login_seeded_user):
     change_name.go_to_change_service_name(config['service']['id'])
     change_name.enter_new_name(new_name)
     change_name.click_save()
-    change_name.enter_password(config['service']['seeded_user']['password'])
-    change_name.click_save()
     service_settings.check_service_name(new_name)
 
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])
@@ -476,8 +474,6 @@ def test_change_service_name(driver, login_seeded_user):
     # change the name back
     change_name.go_to_change_service_name(config['service']['id'])
     change_name.enter_new_name(config['service']['name'])
-    change_name.click_save()
-    change_name.enter_password(config['service']['seeded_user']['password'])
     change_name.click_save()
     service_settings.check_service_name(config['service']['name'])
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -936,10 +936,6 @@ class ChangeName(BasePage):
         element.clear()
         element.send_keys(new_name)
 
-    def enter_password(self, password):
-        element = self.wait_for_element(ChangeNameLocators.PASSWORD_FIELD)
-        element.send_keys(password)
-
 
 class EmailReplyTo(BasePage):
 


### PR DESCRIPTION
This was removed in https://github.com/alphagov/notifications-admin/pull/4084