### PR TITLE
Update how we look for the "Preview this alert" button

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -48,7 +48,7 @@ def test_prepare_broadcast_with_new_content(
     prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
     prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    prepare_alert_pages.click_element_by_link_text("Preview this alert")
     # here check if selected areas displayed
     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
@@ -132,7 +132,7 @@ def test_prepare_broadcast_with_template(
     prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
     prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    prepare_alert_pages.click_element_by_link_text("Preview this alert")
     # here check if selected areas displayed
     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")


### PR DESCRIPTION
It was changed in https://github.com/alphagov/notifications-admin/pull/4170 to be a link styled like a button instead of a real button.