### PR TITLE
fix not being able to run broadcast tests locally

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,11 +48,13 @@ urls = {
     },
     'staging': {
         'api': 'https://api.staging-notify.works',
-        'admin': 'https://www.staging-notify.works'
+        'admin': 'https://www.staging-notify.works',
+        'govuk_alerts': 'not used in this environment'
     },
     'live': {
         'api': 'https://api.notifications.service.gov.uk',
-        'admin': 'https://www.notifications.service.gov.uk'
+        'admin': 'https://www.notifications.service.gov.uk',
+        'govuk_alerts': 'not used in this environment'
     }
 }
 

--- a/config.py
+++ b/config.py
@@ -38,11 +38,13 @@ config = {
 urls = {
     'dev': {
         'api': 'http://localhost:6011',
-        'admin': 'http://localhost:6012'
+        'admin': 'http://localhost:6012',
+        'govuk_alerts': 'http://localhost:6017/alerts'
     },
     'preview': {
         'api': 'https://api.notify.works',
-        'admin': 'https://www.notify.works'
+        'admin': 'https://www.notify.works',
+        'govuk_alerts': 'https://www.integration.publishing.service.gov.uk/alerts'
     },
     'staging': {
         'api': 'https://api.staging-notify.works',
@@ -68,6 +70,7 @@ def setup_shared_config():
         'env': env,
         'notify_api_url': urls[env]['api'],
         'notify_admin_url': urls[env]['admin'],
+        'govuk_alerts_url': urls[env]['govuk_alerts']
     })
 
 
@@ -75,8 +78,6 @@ def setup_preview_dev_config():
     uuid_for_test_run = str(uuid.uuid4())
 
     config.update({
-        'gov_uk_alerts_url': 'https://www.integration.publishing.service.gov.uk/alerts',
-
         'service_name': 'Functional Test_{}'.format(uuid_for_test_run),
 
         'user': {

--- a/db_setup_fixtures.sql
+++ b/db_setup_fixtures.sql
@@ -74,7 +74,7 @@ ea0ec5d2-ce6c-4499-98d7-60a94fd72800	8e1d56fa-12a8-4d00-bed2-db47180bed0a	0d2e9b
 
 
 COPY service_broadcast_settings (service_id, channel, created_at, updated_at, provider) FROM stdin;
-8e1d56fa-12a8-4d00-bed2-db47180bed0a	test	2021-07-14 14:37:35.103872	\N	all
+8e1d56fa-12a8-4d00-bed2-db47180bed0a	severe	2021-07-14 14:37:35.103872	\N	all
 \.
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1144,7 +1144,7 @@ class BroadcastFreeformPage(BasePage):
 
 class GovUkAlertsPage(BasePage):
     def __init__(self, driver):
-        self.gov_uk_alerts_url = config['gov_uk_alerts_url']
+        self.gov_uk_alerts_url = config['govuk_alerts_url']
         self.driver = driver
 
     def get(self):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

running the functional tests locally is a useful way to check my
local environment is working properly. these tests are also in the
"preview_and_dev" directory, so they should work locally.

this fixes the urls for local testing and also an inconsistency in
the service settings compared to preview: the tests check an alert
shows up on /alerts, but this won't happen for test alerts.