### PR TITLE
Add tests for sending broadcasts using the API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # W503: line break before binary operator
-exclude = venv*,__pycache__,cache
+exclude = venv*,__pycache__,cache,sample_cap_xml.py
 ignore = W503
 max-complexity = 8
 max-line-length = 120

--- a/broadcast_client/broadcast_client.py
+++ b/broadcast_client/broadcast_client.py
@@ -1,0 +1,35 @@
+import urllib.parse
+
+from notifications_python_client.base import BaseAPIClient
+from notifications_python_client.authentication import create_jwt_token
+
+
+class BroadcastClient(BaseAPIClient):
+    def generate_headers(self, api_token):
+        return {
+            "Content-type": "application/cap+xml",
+            "Authorization": f"Bearer {api_token}",
+        }
+
+    def _create_request_objects(self, url, data, *args):
+        """
+        This overwrites `_create_request_objects` in the BaseAPIClient to send the raw data instead of data
+        which has been JSON serialized.
+        """
+        api_token = create_jwt_token(
+            self.api_key,
+            self.service_id
+        )
+
+        kwargs = {
+            "headers": self.generate_headers(api_token),
+            "timeout": self.timeout,
+            "data": data,
+        }
+
+        url = urllib.parse.urljoin(self.base_url, url)
+
+        return url, kwargs
+
+    def post_broadcast_data(self, data):
+        return self.post('/v2/broadcast', data=data)

--- a/config.py
+++ b/config.py
@@ -103,6 +103,7 @@ def setup_preview_dev_config():
                 # we are re-using seeded user's password
                 'password': os.environ['FUNCTIONAL_TESTS_SERVICE_EMAIL_PASSWORD'],
             },
+            'api_key_live': os.environ['BROADCAST_SERVICE_LIVE_API_KEY'],
         },
 
         'service': {

--- a/db_setup_fixtures.sql
+++ b/db_setup_fixtures.sql
@@ -24,12 +24,14 @@ COPY api_keys (id, name, secret, service_id, expiry_date, created_at, created_by
 ccadd239-bae1-4ade-9f5b-fc389a1622a9	govuk_notify	IjhmNjBiNDIzLTkwZmItNGQ0OC1hN2NiLTYyZTc1ODBjZDg4MSI.IRb1WKwUfeMS0AhcG9cUDkr5m50	d6aa2c68-a2d9-4437-ab19-3ae8eb202553	\N	2019-03-25 14:57:08.679353	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	\N	1	normal
 c1d8e17f-3abe-4858-913e-d88f689ca430	functional_tests_service_live_key	Ijg0NmE4OTc1LTllMzctNDUzMC1iYTJiLTZlZDUzODE5Yjc4ZCI.S9_8a8r5rGLqvFhwC2AOXT1g3C4	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	2019-03-25 15:07:17.182987	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	\N	1	normal
 9e80ccb3-98fb-4b0b-84c0-40a9443e326b	functional_tests_service_test_key	ImZmYWYyZGVjLWU3ZGEtNGZiZS1iY2M3LWNlNmFkNTFlM2I1ZSI.hU8Q_AkTwYvlsdYyShU7H38Qw8U	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	2019-03-25 15:07:44.583174	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	\N	1	test
+22404b3f-779c-49d5-9c3f-46464fb37a62	func_tests_broadcast_service_live_key	ImMzZTZiNjhmLWJkNDMtNGUzMy04ZmJhLTY3YThjMWJhZDRhMyI.58oYXhsespJeQQ0zolZUdfyTnPw	8e1d56fa-12a8-4d00-bed2-db47180bed0a	\N	2019-03-25 15:07:44.583174	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	\N	1	normal
 \.
 
 COPY api_keys_history (id, name, secret, service_id, expiry_date, created_at, updated_at, created_by_id, version, key_type) FROM stdin;
 ccadd239-bae1-4ade-9f5b-fc389a1622a9	govuk_notify	IjhmNjBiNDIzLTkwZmItNGQ0OC1hN2NiLTYyZTc1ODBjZDg4MSI.IRb1WKwUfeMS0AhcG9cUDkr5m50	d6aa2c68-a2d9-4437-ab19-3ae8eb202553	\N	2019-03-25 14:57:08.679353	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	normal
 c1d8e17f-3abe-4858-913e-d88f689ca430	functional_tests_service_live_key	Ijg0NmE4OTc1LTllMzctNDUzMC1iYTJiLTZlZDUzODE5Yjc4ZCI.S9_8a8r5rGLqvFhwC2AOXT1g3C4	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	2019-03-25 15:07:17.182987	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	normal
 9e80ccb3-98fb-4b0b-84c0-40a9443e326b	functional_tests_service_test_key	ImZmYWYyZGVjLWU3ZGEtNGZiZS1iY2M3LWNlNmFkNTFlM2I1ZSI.hU8Q_AkTwYvlsdYyShU7H38Qw8U	34b725f0-1f47-49bc-a9f5-aa2a84587c53	\N	2019-03-25 15:07:44.583174	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	test
+22404b3f-779c-49d5-9c3f-46464fb37a62	func_tests_broadcast_service_live_key	ImMzZTZiNjhmLWJkNDMtNGUzMy04ZmJhLTY3YThjMWJhZDRhMyI.58oYXhsespJeQQ0zolZUdfyTnPw	8e1d56fa-12a8-4d00-bed2-db47180bed0a	\N	2019-03-25 15:07:44.583174	\N	c76a2961-08dc-4ec5-ac07-57ec9d7cef1b	1	normal
 \.
 
 COPY templates_history (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, service_letter_contact_id, hidden, postage, broadcast_data) FROM stdin;

--- a/environment_local.sh
+++ b/environment_local.sh
@@ -34,3 +34,4 @@ export BROADCAST_USER_1_EMAIL='notify-tests-preview+local-broadcast1@digital.cab
 export BROADCAST_USER_2_EMAIL='notify-tests-preview+local-broadcast2@digital.cabinet-office.gov.uk'
 
 export BROADCAST_SERVICE_ID='8e1d56fa-12a8-4d00-bed2-db47180bed0a'
+export BROADCAST_SERVICE_LIVE_API_KEY='func_tests_broadcast_service_live_key-8e1d56fa-12a8-4d00-bed2-db47180bed0a-c3e6b68f-bd43-4e33-8fba-67a8c1bad4a3'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from notifications_python_client import NotificationsAPIClient
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 
+from broadcast_client.broadcast_client import BroadcastClient
 from config import config, setup_shared_config
 from tests.pages.pages import HomePage
 from tests.pages.rollups import sign_in, sign_in_email_auth
@@ -92,5 +93,14 @@ def seeded_client_using_test_key():
     client = NotificationsAPIClient(
         base_url=config['notify_api_url'],
         api_key=config['service']['api_test_key']
+    )
+    return client
+
+
+@pytest.fixture(scope="module")
+def broadcast_client():
+    client = BroadcastClient(
+        api_key=config['broadcast_service']['api_key_live'],
+        base_url=config['notify_api_url'],
     )
     return client

--- a/tests/functional/preview_and_dev/sample_cap_xml.py
+++ b/tests/functional/preview_and_dev/sample_cap_xml.py
@@ -1,0 +1,61 @@
+ALERT_XML = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+        <identifier>{identifier}</identifier>
+        <sender>www.gov.uk/environment-agency</sender>
+        <sent>{alert_sent}</sent>
+        <status>Actual</status>
+        <msgType>Alert</msgType>
+        <scope>Public</scope>
+        <info>
+            <language>en-GB</language>
+            <category>Met</category>
+            <event>{event}</event>
+            <urgency>Immediate</urgency>
+            <severity>Severe</severity>
+            <certainty>Likely</certainty>
+            <expires>2022-03-15T12:12:13-00:00</expires>
+            <senderName>Environment Agency</senderName>
+            <description>A severe flood warning has been issued</description>
+            <instruction>Check the latest information for your area. </instruction>
+            <area>
+                <areaDesc>River Steeping</areaDesc>
+                <polygon>53.10569,0.24453 53.10593,0.24430 53.10601,0.24375 53.10615,0.24349 53.10629,0.24356 53.10656,0.24336 53.10697,0.24354 53.10684,0.24298 53.10694,0.24264 53.10721,0.24302 53.10752,0.24310 53.10777,0.24308 53.10805,0.24320 53.10803,0.24187 53.10776,0.24085 53.10774,0.24062 53.10702,0.24056 53.10679,0.24088 53.10658,0.24071 53.10651,0.24049 53.10656,0.24022 53.10642,0.24022 53.10632,0.24052 53.10629,0.24082 53.10612,0.24093 53.10583,0.24133 53.10564,0.24178 53.10541,0.24282 53.10569,0.24453</polygon>
+                <geocode>
+                    <valueName>TargetAreaCode</valueName>
+                    <value>053FWFSTEEP4</value>
+                </geocode>
+            </area>
+        </info>
+    </alert>
+"""
+
+CANCEL_XML = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+        <identifier>{identifier}</identifier>
+        <sender>www.gov.uk/environment-agency</sender>
+        <sent>{cancel_sent}</sent>
+        <status>Actual</status>
+        <msgType>Cancel</msgType>
+        <scope>Public</scope>
+        <references>www.gov.uk/environment-agency,{identifier},{alert_sent}</references>
+        <info>
+            <language>en-GB</language>
+            <category>Met</category>
+            <event>{event}</event>
+            <urgency>Immediate</urgency>
+            <severity>Severe</severity>
+            <certainty>Likely</certainty>
+            <expires>{expires}</expires>
+            <senderName>Environment Agency</senderName>
+            <description></description>
+            <area>
+                <areaDesc>River Steeping</areaDesc>
+                <polygon>53.10569,0.24453 53.10593,0.24430 53.10601,0.24375 53.10615,0.24349 53.10629,0.24356 53.10656,0.24336 53.10697,0.24354 53.10684,0.24298 53.10694,0.24264 53.10721,0.24302 53.10752,0.24310 53.10777,0.24308 53.10805,0.24320 53.10803,0.24187 53.10776,0.24085 53.10774,0.24062 53.10702,0.24056 53.10679,0.24088 53.10658,0.24071 53.10651,0.24049 53.10656,0.24022 53.10642,0.24022 53.10632,0.24052 53.10629,0.24082 53.10612,0.24093 53.10583,0.24133 53.10564,0.24178 53.10541,0.24282 53.10569,0.24453</polygon>
+                <geocode>
+                    <valueName>TargetAreaCode</valueName>
+                    <value>053FWFSTEEP4</value>
+                </geocode>
+            </area>
+        </info>
+    </alert>
+"""

--- a/tests/functional/preview_and_dev/sample_cap_xml.py
+++ b/tests/functional/preview_and_dev/sample_cap_xml.py
@@ -13,9 +13,9 @@ ALERT_XML = """
             <urgency>Immediate</urgency>
             <severity>Severe</severity>
             <certainty>Likely</certainty>
-            <expires>2022-03-15T12:12:13-00:00</expires>
+            <expires>2022-06-15T12:12:13-00:00</expires>
             <senderName>Environment Agency</senderName>
-            <description>A severe flood warning has been issued</description>
+            <description>{broadcast_content}</description>
             <instruction>Check the latest information for your area. </instruction>
             <area>
                 <areaDesc>River Steeping</areaDesc>
@@ -45,7 +45,7 @@ CANCEL_XML = """
             <urgency>Immediate</urgency>
             <severity>Severe</severity>
             <certainty>Likely</certainty>
-            <expires>{expires}</expires>
+            <expires>2022-06-15T12:12:13-00:00</expires>
             <senderName>Environment Agency</senderName>
             <description></description>
             <area>

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -10,11 +10,11 @@ from tests.pages import (
     BasePage,
     BroadcastFreeformPage,
     DashboardPage,
-    GovUkAlertsPage,
     ShowTemplatesPage,
 )
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
+    check_alert_is_published_on_govuk_alerts,
     convert_naive_utc_datetime_to_cap_standard_string,
     create_broadcast_template,
     delete_template,
@@ -74,12 +74,7 @@ def test_prepare_broadcast_with_new_content(
     assert current_alerts_page.is_text_present_on_page("Live since ")
     alert_page_url = current_alerts_page.current_url
 
-    # check if alert is published on gov.uk/alerts
-    gov_uk_alerts_page = GovUkAlertsPage(driver)
-    gov_uk_alerts_page.get()
-    page_title = 'Current alerts'
-    gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(page_title=page_title, broadcast_content=broadcast_content)
+    check_alert_is_published_on_govuk_alerts(driver, 'Current alerts', broadcast_content)
 
     # get back to the alert page
     current_alerts_page.get(alert_page_url)
@@ -92,12 +87,7 @@ def test_prepare_broadcast_with_new_content(
     past_alerts_page = BasePage(driver)
     assert past_alerts_page.is_text_present_on_page(broadcast_title)
 
-    # check if alert on gov.uk/alerts is moved to past alerts
-    gov_uk_alerts_page = GovUkAlertsPage(driver)
-    gov_uk_alerts_page.get()
-    page_title = 'Past alerts'
-    gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(page_title=page_title, broadcast_content=broadcast_content)
+    check_alert_is_published_on_govuk_alerts(driver, 'Past alerts', broadcast_content)
 
     # sign out
     current_alerts_page.get()
@@ -210,13 +200,9 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     assert page.is_text_present_on_page("Live since ")
     alert_page_url = page.current_url
 
-    # check if alert is published on gov.uk/alerts
-    gov_uk_alerts_page = GovUkAlertsPage(driver)
-    gov_uk_alerts_page.get()
-    page_title = 'Current alerts'
-    gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(
-        page_title=page_title,
+    check_alert_is_published_on_govuk_alerts(
+        driver,
+        page_title='Current alerts',
         broadcast_content='A severe flood warning has been issued',
     )
 
@@ -237,13 +223,9 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     page.click_element_by_link_text('Past alerts')
     assert page.is_text_present_on_page(event)
 
-    # check if alert on gov.uk/alerts is moved to past alerts
-    gov_uk_alerts_page = GovUkAlertsPage(driver)
-    gov_uk_alerts_page.get()
-    page_title = 'Past alerts'
-    gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(
-        page_title=page_title,
+    check_alert_is_published_on_govuk_alerts(
+        driver,
+        page_title='Past alerts',
         broadcast_content='A severe flood warning has been issued',
     )
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -150,11 +150,16 @@ def test_prepare_broadcast_with_template(
 def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    expires_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() + timedelta(hours=1))
     identifier = uuid.uuid4()
     event = f'test broadcast {identifier}'
+    broadcast_content = f'Flood warning {identifier} has been issued'
 
-    new_alert_xml = ALERT_XML.format(identifier=identifier, alert_sent=sent_time, event=event)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
     broadcast_client.post_broadcast_data(new_alert_xml)
 
     sign_in(driver, account_type='broadcast_approve_user')
@@ -169,7 +174,6 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
         alert_sent=sent_time,
         cancel_sent=cancel_time,
         event=event,
-        expires=expires_time,
     )
     broadcast_client.post_broadcast_data(reject_broadcast_xml)
 
@@ -183,11 +187,16 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
 def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    expires_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() + timedelta(hours=1))
     identifier = uuid.uuid4()
     event = f'test broadcast {identifier}'
+    broadcast_content = f'Flood warning {identifier} has been issued'
 
-    new_alert_xml = ALERT_XML.format(identifier=identifier, alert_sent=sent_time, event=event)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
     broadcast_client.post_broadcast_data(new_alert_xml)
 
     sign_in(driver, account_type='broadcast_approve_user')
@@ -200,18 +209,13 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     assert page.is_text_present_on_page("Live since ")
     alert_page_url = page.current_url
 
-    check_alert_is_published_on_govuk_alerts(
-        driver,
-        page_title='Current alerts',
-        broadcast_content='A severe flood warning has been issued',
-    )
+    check_alert_is_published_on_govuk_alerts(driver, 'Current alerts', broadcast_content)
 
     cancel_broadcast_xml = CANCEL_XML.format(
         identifier=identifier,
         alert_sent=sent_time,
         cancel_sent=cancel_time,
         event=event,
-        expires=expires_time,
     )
     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
@@ -223,11 +227,7 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     page.click_element_by_link_text('Past alerts')
     assert page.is_text_present_on_page(event)
 
-    check_alert_is_published_on_govuk_alerts(
-        driver,
-        page_title='Past alerts',
-        broadcast_content='A severe flood warning has been issued',
-    )
+    check_alert_is_published_on_govuk_alerts(driver, 'Past alerts', broadcast_content)
 
     page.get()
     page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,6 +1,11 @@
 import uuid
+from datetime import datetime, timedelta
 
 from config import config
+from tests.functional.preview_and_dev.sample_cap_xml import (
+    ALERT_XML,
+    CANCEL_XML,
+)
 from tests.pages import (
     BasePage,
     BroadcastFreeformPage,
@@ -10,6 +15,7 @@ from tests.pages import (
 )
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
+    convert_naive_utc_datetime_to_cap_standard_string,
     create_broadcast_template,
     delete_template,
     go_to_templates_page,
@@ -146,3 +152,100 @@ def test_prepare_broadcast_with_template(
     assert rejected_alerts_page.is_text_present_on_page(template_name)
 
     delete_template(driver, template_name, service='broadcast_service')
+
+    prepare_alert_pages.sign_out()
+
+
+@recordtime
+def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    expires_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() + timedelta(hours=1))
+    identifier = uuid.uuid4()
+    event = f'test broadcast {identifier}'
+
+    new_alert_xml = ALERT_XML.format(identifier=identifier, alert_sent=sent_time, event=event)
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type='broadcast_approve_user')
+    page = BasePage(driver)
+    page.click_element_by_link_text('Current alerts')
+    page.click_element_by_link_text(event)
+
+    assert page.is_text_present_on_page(f'An API call wants to broadcast {event}')
+
+    reject_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+        expires=expires_time,
+    )
+    broadcast_client.post_broadcast_data(reject_broadcast_xml)
+
+    page.click_element_by_link_text('Rejected alerts')
+    assert page.is_text_present_on_page(event)
+
+    page.sign_out()
+
+
+@recordtime
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    expires_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() + timedelta(hours=1))
+    identifier = uuid.uuid4()
+    event = f'test broadcast {identifier}'
+
+    new_alert_xml = ALERT_XML.format(identifier=identifier, alert_sent=sent_time, event=event)
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type='broadcast_approve_user')
+
+    page = BasePage(driver)
+    page.click_element_by_link_text('Current alerts')
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_continue()
+    assert page.is_text_present_on_page("Live since ")
+    alert_page_url = page.current_url
+
+    # check if alert is published on gov.uk/alerts
+    gov_uk_alerts_page = GovUkAlertsPage(driver)
+    gov_uk_alerts_page.get()
+    page_title = 'Current alerts'
+    gov_uk_alerts_page.click_element_by_link_text(page_title)
+    gov_uk_alerts_page.check_alert_is_published(
+        page_title=page_title,
+        broadcast_content='A severe flood warning has been issued',
+    )
+
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+        expires=expires_time,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+    # go back to the page for the current alert
+    page.get(alert_page_url)
+
+    # assert that it's now cancelled
+    assert page.is_text_present_on_page('Stopped by an API call')
+    page.click_element_by_link_text('Past alerts')
+    assert page.is_text_present_on_page(event)
+
+    # check if alert on gov.uk/alerts is moved to past alerts
+    gov_uk_alerts_page = GovUkAlertsPage(driver)
+    gov_uk_alerts_page.get()
+    page_title = 'Past alerts'
+    gov_uk_alerts_page.click_element_by_link_text(page_title)
+    gov_uk_alerts_page.check_alert_is_published(
+        page_title=page_title,
+        broadcast_content='A severe flood warning has been issued',
+    )
+
+    page.get()
+    page.sign_out()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -207,7 +207,9 @@ class BasePage(object):
         return element.text == expected_page_title
 
     def is_text_present_on_page(self, search_text):
-        return search_text in self.driver.page_source
+        normalized_page_source = ' '.join(self.driver.page_source.split())
+
+        return search_text in normalized_page_source
 
     def get_template_id(self):
         # e.g.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from tests.pages import (
     EditEmailTemplatePage,
     EditSmsTemplatePage,
     EmailReplyTo,
+    GovUkAlertsPage,
     InviteUserPage,
     MainPage,
     RegisterFromInvite,
@@ -455,3 +456,15 @@ def do_user_can_update_reply_to_email_to_service(driver):
     assert email_address2 + default in body.text
 
     dashboard_page.go_to_dashboard_for_service(service_id)
+
+
+def check_alert_is_published_on_govuk_alerts(driver, page_title, broadcast_content):
+    gov_uk_alerts_page = GovUkAlertsPage(driver)
+    gov_uk_alerts_page.get()
+
+    gov_uk_alerts_page.click_element_by_link_text(page_title)
+
+    gov_uk_alerts_page.check_alert_is_published(
+        page_title=page_title,
+        broadcast_content=broadcast_content,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,6 +60,16 @@ def create_temp_csv(fields):
     return directory_name, csv_filename
 
 
+def convert_naive_utc_datetime_to_cap_standard_string(dt):
+    """
+    As defined in section 3.3.2 of
+    http://docs.oasis-open.org/emergency/cap/v1.2/CAP-v1.2-os.html
+    They define the standard "YYYY-MM-DDThh:mm:ssXzh:zm", where X is
+    `+` if the timezone is > UTC, otherwise `-`
+    """
+    return f"{dt.strftime('%Y-%m-%dT%H:%M:%S')}-00:00"
+
+
 class RetryException(Exception):
     pass
 


### PR DESCRIPTION
This adds two new tests to test sending, rejecting and cancelling a broadcast using the API
1. The first creates a broadcast using the api, then uses the api to reject it (before it is approved)
2. The second creates a broadcast using the api. This then gets approved in the admin interface and rejected using the api.

[Pivotal story](https://www.pivotaltracker.com/story/show/179120842)