### PR TITLE
refresh web page if alert isn't present

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,6 +1,8 @@
 import os
 import shutil
+import time
 
+import pytest
 from retry import retry
 from selenium.common.exceptions import (
     NoSuchElementException,
@@ -1153,12 +1155,9 @@ class GovUkAlertsPage(BasePage):
         self.driver.get(self.gov_uk_alerts_url)
 
     def check_alert_is_published(self, broadcast_content):
-        locator = (By.XPATH, f"//p[text() = '{broadcast_content}']")
         for x in range(6):
-            try:
-                self.wait_for_invisible_element(locator)
-                assert self.is_text_present_on_page(broadcast_content)
+            if self.is_text_present_on_page(broadcast_content):
                 return
-            except TimeoutException:
-                self.driver.refresh()
-        raise TimeoutException  # if alert not present after this time, raise exception
+            time.sleep(3)
+            self.driver.refresh()
+        pytest.fail(f'Could not find alert with content "{broadcast_content}" despite waiting')

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1155,9 +1155,9 @@ class GovUkAlertsPage(BasePage):
         self.driver.get(self.gov_uk_alerts_url)
 
     def check_alert_is_published(self, broadcast_content):
-        for x in range(6):
+        for x in range(12):
             if self.is_text_present_on_page(broadcast_content):
                 return
-            time.sleep(3)
+            time.sleep(10)
             self.driver.refresh()
-        pytest.fail(f'Could not find alert with content "{broadcast_content}" despite waiting')
+        pytest.fail(f'Could not find alert with content "{broadcast_content}" despite waiting 2 mins')

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1152,13 +1152,13 @@ class GovUkAlertsPage(BasePage):
     def get(self):
         self.driver.get(self.gov_uk_alerts_url)
 
-    def check_alert_is_published(self, page_title, broadcast_content):
-        locator = (By.XPATH, "//p[text() = '{}']".format(broadcast_content))
+    def check_alert_is_published(self, broadcast_content):
+        locator = (By.XPATH, f"//p[text() = '{broadcast_content}']")
         for x in range(6):
             try:
                 self.wait_for_invisible_element(locator)
                 assert self.is_text_present_on_page(broadcast_content)
                 return
             except TimeoutException:
-                self.click_element_by_link_text(page_title)  # refresh page
+                self.driver.refresh()
         raise TimeoutException  # if alert not present after this time, raise exception

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -464,7 +464,4 @@ def check_alert_is_published_on_govuk_alerts(driver, page_title, broadcast_conte
 
     gov_uk_alerts_page.click_element_by_link_text(page_title)
 
-    gov_uk_alerts_page.check_alert_is_published(
-        page_title=page_title,
-        broadcast_content=broadcast_content,
-    )
+    gov_uk_alerts_page.check_alert_is_published(broadcast_content)


### PR DESCRIPTION
clicking the element by link text with page title ('Current alerts') won't work because that's not a link, it's just a h1. use driver.refresh instead.

Increase the timeout too