### PR TITLE
Update xpath for templates page

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -473,7 +473,7 @@ class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
     def template_link_text(link_text):
         return (
             By.XPATH,
-            "//nav[contains(@id,'template-list')]//a/span[contains(normalize-space(.), '{}')]".format(link_text)
+            "//div[contains(@id,'template-list')]//a/span[contains(normalize-space(.), '{}')]".format(link_text)
         )
 
     @staticmethod


### PR DESCRIPTION
Since https://github.com/alphagov/notifications-admin/pull/4279, the templates are now in a `<div>` instead of a `<nav>`, so this updates the xpath used to find them.