### PR TITLE
Increase alerts test retries to 24

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,7 @@ config = {
     'provider_retry_interval': 22,
     'verify_code_retry_times': 8,
     'verify_code_retry_interval': 9,
-    'govuk_alerts_wait_retry_times': 12,
+    'govuk_alerts_wait_retry_times': 24,
     'govuk_alerts_wait_retry_interval': 10,
     'functional_test_service_name': 'Functional Test Service_',
 


### PR DESCRIPTION
Slow Fastly purges coupled with rendering of many static alerts pages causes this test to time out before an alert appears on the page.

24 x 10s interval = 240 seconds