### PR TITLE
Parallelise tests in preview environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ clean: ## Remove temporary files
 test: clean ## Run functional tests against local environment
 	isort --check-only tests
 	flake8 .
-	pytest -v tests/functional/preview_and_dev
+	pytest -v tests/functional/preview_and_dev -n auto --dist loadgroup
 	pytest -v tests/document_download

--- a/README.md
+++ b/README.md
@@ -85,6 +85,33 @@ source environment_{env_name}.sh
 pytest tests/document_download
 ```
 
+### Running tests in parallel
+
+We can reduce the duration of the test suite by running some tests in parallel.
+
+We use the pytest [x-dist plugin](https://pypi.org/project/pytest-xdist/) to support running tests in parallel automatically. The number of test runners is determined automatically using the `pytest -n auto` option. This will be set to the number of CPUs available on the test machine.
+
+Each test runner launches a separate selenium/chromedriver instance so browser state is isolated between runners.
+
+#### Defining parallel groups
+
+We execute tests in parallel groups using the `pytest --dist loadgroup` option. This allows us to group tests by the authenticated user type or other logical domain - this is useful for functional tests that rely on a particular state of a real user environment during execution.
+
+Parallel tests executed using the same user type can cause race conditions and interfere with other tests. Tests belonging to different groups are executed in parallel. Each test within the same group is executed sequentially by the same test runner.
+
+We use the following annotations on test methods to define the groups:
+
+```python
+@pytest.mark.xdist_group(name="seeded-user")
+@pytest.mark.xdist_group(name="registration-flow")
+@pytest.mark.xdist_group(name="api-client")
+@pytest.mark.xdist_group(name="seeded-email")
+@pytest.mark.xdist_group(name="broadcasts")
+@pytest.mark.xdist_group(name="api-letters")
+```
+
+More groups generally equals better parallelisation (limited by test runner count). However, in the case of functional tests, increased parallelisation increases the risk of side effects and race conditions in the shared environment unless grouped carefully.
+
 ## Further documentation
 
 - [Updating db_setup_fixtures](docs/update-db_setup_fixtures.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest==7.1.2
 retry==0.9.2
 selenium==4.3.0
 notifications-python-client==6.3.0
+pytest-xdist==2.5.0

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,6 +1,8 @@
 import uuid
 from datetime import datetime, timedelta
 
+import pytest
+
 from config import config
 from tests.functional.preview_and_dev.sample_cap_xml import (
     ALERT_XML,
@@ -24,6 +26,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.xdist_group(name="broadcasts")
 def test_prepare_broadcast_with_new_content(
     driver
 ):
@@ -95,6 +98,7 @@ def test_prepare_broadcast_with_new_content(
 
 
 @recordtime
+@pytest.mark.xdist_group(name="broadcasts")
 def test_prepare_broadcast_with_template(
     driver
 ):
@@ -147,6 +151,7 @@ def test_prepare_broadcast_with_template(
 
 
 @recordtime
+@pytest.mark.xdist_group(name="broadcasts")
 def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
@@ -184,6 +189,7 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
 
 
 @recordtime
+@pytest.mark.xdist_group(name="broadcasts")
 def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())

--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -1,3 +1,5 @@
+import pytest
+
 from config import config
 from tests.pages import (
     BasePage,
@@ -10,6 +12,7 @@ from tests.test_utils import do_email_verification, recordtime
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-email")
 def test_email_auth(driver):
     # login email auth user
     sign_in_email_auth(driver)
@@ -20,6 +23,7 @@ def test_email_auth(driver):
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_reset_forgotten_password(driver):
     email, password = get_email_and_password(account_type='seeded')
     sign_in_page = SignInPage(driver)

--- a/tests/functional/preview_and_dev/test_inbound_sms.py
+++ b/tests/functional/preview_and_dev/test_inbound_sms.py
@@ -43,6 +43,7 @@ def inbound_sms():
     return message
 
 
+@pytest.mark.xdist_group(name="api-client")
 def test_inbound_api(inbound_sms, seeded_client):
     # this'll raise if the message isn't in the list.
     next(
@@ -52,6 +53,7 @@ def test_inbound_api(inbound_sms, seeded_client):
     )
 
 
+@pytest.mark.xdist_group(name="seeded-user")
 def test_inbox_page(inbound_sms, driver, login_seeded_user):
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(config['service']['id'])

--- a/tests/functional/preview_and_dev/test_notify_api_letter.py
+++ b/tests/functional/preview_and_dev/test_notify_api_letter.py
@@ -22,6 +22,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.xdist_group(name="api-client")
 def test_send_letter_notification_via_api(seeded_client_using_test_key):
     notification_id = send_notification_via_api(
         seeded_client_using_test_key,
@@ -40,6 +41,7 @@ def test_send_letter_notification_via_api(seeded_client_using_test_key):
 
 
 @recordtime
+@pytest.mark.xdist_group(name="api-letters")
 @pytest.mark.antivirus
 def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_key):
 
@@ -62,6 +64,7 @@ def test_send_precompiled_letter_notification_via_api(seeded_client_using_test_k
 
 
 @recordtime
+@pytest.mark.xdist_group(name="api-letters")
 @pytest.mark.antivirus
 def test_send_precompiled_letter_with_virus_notification_via_api(seeded_client_using_test_key):
 

--- a/tests/functional/preview_and_dev/test_org_invite.py
+++ b/tests/functional/preview_and_dev/test_org_invite.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from config import config, generate_unique_email
 from tests.pages import (
     DashboardPage,
@@ -12,6 +14,7 @@ from tests.test_utils import do_verify, get_link, recordtime
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_org_invite(driver, login_seeded_user):
     org_dashboard_page = OrganisationDashboardPage(driver)
     org_dashboard_page.go_to_dashboard_for_org(config['service']['organisation_id'])

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.pages import DashboardPage, SmsSenderPage
 from tests.test_utils import (
     do_user_can_add_reply_to_email_to_service,
@@ -9,6 +11,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.xdist_group(name="registration-flow")
 def test_registration_and_invite_flow(driver):
     do_user_registration(driver)
     do_user_can_add_reply_to_email_to_service(driver)

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -224,6 +224,7 @@ def test_send_sms_with_placeholders_to_one_recipient(
 
 
 @pytest.mark.template_preview
+@pytest.mark.xdist_group(name="seeded-user")
 def test_view_precompiled_letter_message_log_delivered(
         driver,
         login_seeded_user,
@@ -253,6 +254,7 @@ def test_view_precompiled_letter_message_log_delivered(
 
 
 @pytest.mark.template_preview
+@pytest.mark.xdist_group(name="seeded-user")
 def test_view_precompiled_letter_preview_delivered(
         driver,
         login_seeded_user,
@@ -303,6 +305,7 @@ def test_view_precompiled_letter_preview_delivered(
 
 
 @pytest.mark.antivirus
+@pytest.mark.xdist_group(name="seeded-user")
 def test_view_precompiled_letter_message_log_virus_scan_failed(
         driver,
         login_seeded_user,
@@ -331,6 +334,7 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(
     assert ref_link not in link
 
 
+@pytest.mark.xdist_group(name="seeded-user")
 def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user):
     # create new template
     template_name = 'template-for-folder-test {}'.format(uuid.uuid4())
@@ -393,6 +397,7 @@ def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user
     assert template_name not in [x.text for x in driver.find_elements(By.CLASS_NAME, 'message-name')]
 
 
+@pytest.mark.xdist_group(name="seeded-user")
 def test_template_folder_permissions(driver, login_seeded_user):
     family_id = uuid.uuid4()
     folder_names = [
@@ -472,6 +477,7 @@ def test_template_folder_permissions(driver, login_seeded_user):
         manage_folder_page.confirm_delete_folder()
 
 
+@pytest.mark.xdist_group(name="seeded-user")
 def test_change_service_name(driver, login_seeded_user):
     new_name = "Functional Tests {}".format(uuid.uuid4())
     dashboard_page = DashboardPage(driver)

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -50,6 +50,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 @pytest.mark.parametrize('message_type', ['sms', 'email', pytest.param('letter', marks=pytest.mark.template_preview)])
 def test_send_csv(driver, login_seeded_user, seeded_client, seeded_client_using_test_key, message_type):
     dashboard_page = DashboardPage(driver)
@@ -93,6 +94,7 @@ def test_send_csv(driver, login_seeded_user, seeded_client, seeded_client_using_
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_edit_and_delete_email_template(driver, login_seeded_user, seeded_client):
     test_name = 'edit/delete email template test'
     go_to_templates_page(driver)
@@ -115,6 +117,7 @@ def test_edit_and_delete_email_template(driver, login_seeded_user, seeded_client
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_edit_and_delete_sms_template(driver, login_seeded_user, seeded_client):
     test_name = 'edit/delete sms template test'
     go_to_templates_page(driver)
@@ -138,6 +141,7 @@ def test_edit_and_delete_sms_template(driver, login_seeded_user, seeded_client):
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_send_email_with_placeholders_to_one_recipient(
     driver, seeded_client, login_seeded_user
 ):
@@ -180,6 +184,7 @@ def test_send_email_with_placeholders_to_one_recipient(
 
 
 @recordtime
+@pytest.mark.xdist_group(name="seeded-user")
 def test_send_sms_with_placeholders_to_one_recipient(
     driver, seeded_client, login_seeded_user
 ):


### PR DESCRIPTION
### Context

Functional tests are slow because they run sequentially against a real environment. We can reduce test duration by running some tests in parallel.

### What does this do?

We have added the pytest [x-dist plugin](https://pypi.org/project/pytest-xdist/) to support running tests in parallel automatically. The number of test runners is determined automatically using the `pytest -n auto` option. This will be set to the number of CPUs available on the test machine.

Each test runner launches a separate selenium/chromedriver instance so browser state is isolated between runners.

We refactored test configuration in #423 to support simultaneous authentication of the different user types used in the test suite.

#### Defining parallel groups
We have chosen to execute tests in parallel using "groups" (`pytest --dist loadgroup`). This allows us to group tests by the authenticated user type or other logical domain - this is useful for functional tests that rely on a particular state of a real user environment during execution.

Parallel tests executed using the same user type can cause race conditions and test interference. Tests belonging to different groups are executed in parallel. Each test within a group is executed sequentially by the same test runner. 

We use the following annotations on test methods to define the groups:

```python
@pytest.mark.xdist_group(name="seeded-user")
@pytest.mark.xdist_group(name="registration-flow")
@pytest.mark.xdist_group(name="api-client")
@pytest.mark.xdist_group(name="seeded-email")
@pytest.mark.xdist_group(name="broadcasts")
@pytest.mark.xdist_group(name="api-letters")
```

A rough rule of thumb - More groups = better the parallelisation (limited by test runner count). However, in the case of functional tests, increased parallelisation increases the risk of side effects and race conditions in the shared environment unless grouped carefully.

### Results

Running sequentially, the "preview" functional test suite takes between `~14 - 17` minutes.
Running in parallel on a 4 CPU core Concourse worker, this is reduced to `~9` minutes.