### PR TITLE
Change a locator for the Api integration page

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -83,7 +83,7 @@ class InviteUserPageLocators(object):
 
 class ApiIntegrationPageLocators(object):
     MESSAGE_LOG = (By.CSS_SELECTOR, 'div.api-notifications > details:nth-child(1)')
-    HEADING_BUTTON = (By. CSS_SELECTOR, '.api-notifications-item__heading')
+    HEADING_BUTTON = (By. CSS_SELECTOR, '.govuk-details__summary')
     CLIENT_REFERENCE = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     MESSAGE_LIST = (By.CSS_SELECTOR, '.api-notifications-item__data-value')
     STATUS = (By.CSS_SELECTOR, '.api-notifications-item__data-value:last-of-type')


### PR DESCRIPTION
We are changing the API integration page to use the GOV.UK Frontend details component. This means that it will no longer have a class called `api-notifications-item__heading` on the page, so we need to change one of the locators.

**Merge after the change to the API integration page** 
- [ ] https://github.com/alphagov/notifications-admin/pull/4322