### PR TITLE
Revert "Revert "Update IDs of broadcast areas to use 2021 data set""

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -54,8 +54,8 @@ def test_prepare_broadcast_with_new_content(
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Preview this alert")
     # here check if selected areas displayed
@@ -129,8 +129,8 @@ def test_prepare_broadcast_with_template(
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd20-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Preview this alert")
     # here check if selected areas displayed


### PR DESCRIPTION
Reverts alphagov/notifications-functional-tests#432

Corresponds with https://github.com/alphagov/notifications-admin/pull/4343