### PR TITLE
Update link text for downloading a doc download file

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1080,7 +1080,7 @@ class DocumentDownloadLandingPage(BasePage):
 
 
 class DocumentDownloadPage(BasePage):
-    download_link = (By.LINK_TEXT, "Download this file to your device")
+    download_link = (By.PARTIAL_LINK_TEXT, "Download this file")
 
     def get_download_link(self):
         link = self.wait_for_element(self.download_link)


### PR DESCRIPTION
Func tests were broken by https://github.com/alphagov/document-download-frontend/pull/136

I went for a partial text match rather than updating the link to include (0.1KB) as that feels like detail that the functional tests don't need to care about, plus I know it will shortly change to also add the file type as well. However I don't feel strongly about this choice and can instead change it to be more precise if needed.