### PR TITLE
Add tests for doc dl email auth flow

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
-import uuid
 import os
+import uuid
 
 import pytest
 
@@ -176,18 +176,6 @@ def setup_staging_live_config():
                     # letter template not set up on staging and live
                 },
                 "inbound_number": os.environ["PROVIDER_TEST_INBOUND_NUMBER"],
-            },
-        }
-    )
-
-
-def setup_document_download_config():
-    config.update(
-        {
-            "service": {"id": os.environ["FUNCTIONAL_TESTS_SERVICE_ID"]},
-            "document_download": {
-                "api_host": os.environ["DOCUMENT_DOWNLOAD_API_HOST"],
-                "api_key": os.environ["DOCUMENT_DOWNLOAD_API_KEY"],
             },
         }
     )

--- a/environment_local.sh
+++ b/environment_local.sh
@@ -27,9 +27,6 @@ export JENKINS_BUILD_LETTER_TEMPLATE_ID=c3caccab-b066-4a43-8340-cae8b2887e86
 export MMG_INBOUND_SMS_USERNAME=username
 export MMG_INBOUND_SMS_AUTH=testkey
 
-export DOCUMENT_DOWNLOAD_API_HOST=http://localhost:7000
-export DOCUMENT_DOWNLOAD_API_KEY=auth-token
-
 export BROADCAST_USER_1_EMAIL='notify-tests-preview+local-broadcast1@digital.cabinet-office.gov.uk'
 export BROADCAST_USER_1_NUMBER=07700900002
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ isort==5.10.1
 pytest==7.1.3
 retry==0.9.2
 selenium==4.5.0
-notifications-python-client==6.3.0
+notifications-python-client==6.4.0
 pytest-xdist==2.5.0
 black==22.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,10 @@ from tests.pages.pages import HomePage
 from tests.pages.rollups import sign_in, sign_in_email_auth
 
 
+def pytest_addoption(parser):
+    parser.addoption("--no-headless", action="store_true", default=False)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def shared_config():
     """
@@ -22,13 +26,15 @@ def shared_config():
 
 
 @pytest.fixture(scope="module")
-def _driver():
+def _driver(request):
     http_proxy = os.getenv("HTTP_PROXY")
 
     options = webdriver.chrome.options.Options()
     options.add_argument("--no-sandbox")
-    options.add_argument("--headless")
     options.add_argument("user-agent=Selenium")
+
+    if not request.config.getoption("--no-headless"):
+        options.add_argument("--headless")
 
     if http_proxy is not None and http_proxy != "":
         options.add_argument("--proxy-server={}".format(http_proxy))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,27 @@ def shared_config():
     setup_shared_config()
 
 
+@pytest.fixture(scope="session")
+def download_directory(tmp_path_factory):
+    return tmp_path_factory.mktemp("downloads")
+
+
 @pytest.fixture(scope="module")
-def _driver(request):
+def _driver(request, download_directory):
     http_proxy = os.getenv("HTTP_PROXY")
 
     options = webdriver.chrome.options.Options()
     options.add_argument("--no-sandbox")
     options.add_argument("user-agent=Selenium")
+    options.add_experimental_option(
+        "prefs",
+        {
+            "download.default_directory": str(download_directory),
+            "download.prompt_for_download": False,
+            "download.directory_upgrade": True,
+            "safebrowsing.enabled": False,
+        },
+    )
 
     if not request.config.getoption("--no-headless"):
         options.add_argument("--headless")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def login_seeded_user(_driver):
 
 
 @pytest.fixture(scope="module")
-def client():
+def staging_and_prod_client():
     client = NotificationsAPIClient(
         base_url=config["notify_api_url"], api_key=config["service"]["api_key"]
     )

--- a/tests/document_download/conftest.py
+++ b/tests/document_download/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 
-from config import setup_document_download_config
+from config import setup_preview_dev_config
 
 
 @pytest.fixture(scope="session", autouse=True)
-def document_download_config():
+def preview_dev_config():
     """
     Setup
     """
-    setup_document_download_config()
+    setup_preview_dev_config()

--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -4,21 +4,22 @@ from io import BytesIO
 import pytest
 import requests
 from notifications_python_client import prepare_upload
+from selenium.webdriver.common.by import By
 
 from config import config
-from tests.pages import DocumentDownloadLandingPage, DocumentDownloadPage
+from tests.pages import (
+    DocumentDownloadConfirmEmailPage,
+    DocumentDownloadLandingPage,
+    DocumentDownloadPage,
+)
 
 
-@pytest.mark.antivirus
-def test_document_upload_and_download(driver, seeded_client):
-
-    # add PDF header to trick doc download into thinking its a real pdf
+def _get_test_doc_dl_url(seeded_client, prepare_upload_kwargs):
     file = prepare_upload(
-        BytesIO(b"%PDF-1.4 functional tests file"),
-        confirm_email_before_download=False,
+        BytesIO("foo-bar-baz".encode("utf-8")), **prepare_upload_kwargs
     )
     personalisation = {"build_id": file}
-    email_address = config["user"]["email"]
+    email_address = config["service"]["seeded_user"]["email"]
     template_id = config["service"]["templates"]["email"]
 
     resp_json = seeded_client.send_email_notification(
@@ -29,7 +30,17 @@ def test_document_upload_and_download(driver, seeded_client):
 
     assert download_link
 
-    driver.get(download_link.group(0))
+    return download_link.group(0)
+
+
+@pytest.mark.antivirus
+def test_document_upload_and_download(driver, seeded_client):
+    download_link = _get_test_doc_dl_url(
+        seeded_client,
+        {"confirm_email_before_download": False},
+    )
+
+    driver.get(download_link)
 
     landing_page = DocumentDownloadLandingPage(driver)
     assert "Functional Tests" in landing_page.get_service_name()
@@ -41,4 +52,27 @@ def test_document_upload_and_download(driver, seeded_client):
 
     downloaded_document = requests.get(document_url)
 
-    assert downloaded_document.text == "%PDF-1.4 functional tests file"
+    assert downloaded_document.text == "foo-bar-baz"
+
+
+def test_document_download_with_email_confirmation(driver, seeded_client):
+    download_link = _get_test_doc_dl_url(
+        seeded_client,
+        {"confirm_email_before_download": True},
+    )
+
+    driver.get(download_link)
+    landing_page = DocumentDownloadLandingPage(driver)
+    assert "Functional Tests" in landing_page.get_service_name()
+
+    landing_page.go_to_download_page()
+
+    email_confirm_page = DocumentDownloadConfirmEmailPage(driver)
+    email_confirm_page.input_email_address(config["service"]["seeded_user"]["email"])
+    email_confirm_page.click_continue()
+
+    download_page = DocumentDownloadPage(driver)
+    download_page.click_download_link()
+
+    body = driver.find_element(By.TAG_NAME, "body")
+    assert body.text == "foo-bar-baz"

--- a/tests/document_download/test_document_download.py
+++ b/tests/document_download/test_document_download.py
@@ -76,3 +76,27 @@ def test_document_download_with_email_confirmation(driver, seeded_client):
 
     body = driver.find_element(By.TAG_NAME, "body")
     assert body.text == "foo-bar-baz"
+
+
+def test_document_download_with_email_confirmation_rejects_bad_email(
+    driver, seeded_client
+):
+    download_link = _get_test_doc_dl_url(
+        seeded_client,
+        {"confirm_email_before_download": True},
+    )
+
+    driver.get(download_link)
+    landing_page = DocumentDownloadLandingPage(driver)
+    assert "Functional Tests" in landing_page.get_service_name()
+
+    landing_page.go_to_download_page()
+
+    email_confirm_page = DocumentDownloadConfirmEmailPage(driver)
+    email_confirm_page.input_email_address("foo@bar.com")
+    email_confirm_page.click_continue()
+
+    assert (
+        "This is not the email address the file was sent to"
+        in email_confirm_page.get_errors()
+    )

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_email.py
@@ -13,9 +13,9 @@ from tests.test_utils import (
 
 
 @recordtime
-def test_send_email_notification_via_api(client):
+def test_send_email_notification_via_api(staging_and_prod_client):
     notification_id = send_notification_via_api(
-        client,
+        staging_and_prod_client,
         config["service"]["templates"]["email"],
         config["user"]["email"],
         "email",
@@ -23,7 +23,7 @@ def test_send_email_notification_via_api(client):
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, NotificationStatuses.SENT],
+        fargs=[staging_and_prod_client, notification_id, NotificationStatuses.SENT],
         tries=config["notification_retry_times"],
         delay=config["notification_retry_interval"],
     )

--- a/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
+++ b/tests/functional/staging_and_prod/notify_api/test_notify_api_sms.py
@@ -13,14 +13,17 @@ from tests.test_utils import (
 
 
 @recordtime
-def test_send_sms_notification_via_api(client):
+def test_send_sms_notification_via_api(staging_and_prod_client):
     notification_id = send_notification_via_api(
-        client, config["service"]["templates"]["sms"], config["user"]["mobile"], "sms"
+        staging_and_prod_client,
+        config["service"]["templates"]["sms"],
+        config["user"]["mobile"],
+        "sms",
     )
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, NotificationStatuses.SENT],
+        fargs=[staging_and_prod_client, notification_id, NotificationStatuses.SENT],
         tries=config["notification_retry_times"],
         delay=config["notification_retry_interval"],
     )

--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -14,13 +14,17 @@ from tests.test_utils import (
 
 
 @recordtime
-def test_admin(driver, client, login_user):
+def test_admin(driver, staging_and_prod_client, login_user):
     upload_csv_page = UploadCsvPage(driver)
 
     csv_sms_notification_id = send_notification_via_csv(upload_csv_page, "sms")
     csv_sms_notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, csv_sms_notification_id, NotificationStatuses.SENT],
+        fargs=[
+            staging_and_prod_client,
+            csv_sms_notification_id,
+            NotificationStatuses.SENT,
+        ],
         tries=config["notification_retry_times"],
         delay=config["notification_retry_interval"],
     )
@@ -29,7 +33,11 @@ def test_admin(driver, client, login_user):
     csv_email_notification_id = send_notification_via_csv(upload_csv_page, "email")
     csv_email_notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, csv_email_notification_id, NotificationStatuses.SENT],
+        fargs=[
+            staging_and_prod_client,
+            csv_email_notification_id,
+            NotificationStatuses.SENT,
+        ],
         tries=config["notification_retry_times"],
         delay=config["notification_retry_interval"],
     )

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -223,6 +223,11 @@ class BasePage(object):
         element = self.wait_for_element((By.LINK_TEXT, link_text))
         element.click()
 
+    def get_errors(self):
+        error_message = (By.CSS_SELECTOR, ".banner-dangerous")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
+
 
 class PageWithStickyNavMixin:
     def scrollToRevealElement(self, selector=None, xpath=None, stuckToBottom=True):
@@ -1040,7 +1045,15 @@ class ConversationPage(BasePage):
         return next((el for el in elements if content in el.text), None)
 
 
-class DocumentDownloadLandingPage(BasePage):
+class DocumentDownloadBasePage(BasePage):
+    def get_errors(self):
+        # these are diff to notify admin which has the class .banner-dangerous for its error messages
+        error_message = (By.CSS_SELECTOR, ".govuk-error-summary")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
+
+
+class DocumentDownloadLandingPage(DocumentDownloadBasePage):
     continue_button = (By.CSS_SELECTOR, "a.govuk-button")
 
     def get_service_name(self):
@@ -1054,7 +1067,7 @@ class DocumentDownloadLandingPage(BasePage):
         button.click()
 
 
-class DocumentDownloadPage(BasePage):
+class DocumentDownloadPage(DocumentDownloadBasePage):
     download_link = (By.PARTIAL_LINK_TEXT, "Download this ")
 
     def _get_download_link_element(self):
@@ -1069,7 +1082,7 @@ class DocumentDownloadPage(BasePage):
         return self._get_download_link_element().get_attribute("href")
 
 
-class DocumentDownloadConfirmEmailPage(BasePage):
+class DocumentDownloadConfirmEmailPage(DocumentDownloadBasePage):
     continue_button = CommonPageLocators.CONTINUE_BUTTON
     email_input = EmailInputElement()
 
@@ -1095,7 +1108,6 @@ class ManageFolderPage(BasePage):
     name_input = NameInputElement()
     delete_button = (By.NAME, "delete")
     save_button = (By.CSS_SELECTOR, "main [type=submit]")
-    error_message = (By.CSS_SELECTOR, ".banner-dangerous")
 
     def set_name(self, new_name):
         self.name_input = new_name
@@ -1109,10 +1121,6 @@ class ManageFolderPage(BasePage):
     def confirm_delete_folder(self):
         link = self.wait_for_element(self.delete_button)
         link.click()
-
-    def get_errors(self):
-        errors = self.wait_for_element(self.error_message)
-        return errors.text.strip()
 
 
 class BroadcastFreeformPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1057,10 +1057,24 @@ class DocumentDownloadLandingPage(BasePage):
 class DocumentDownloadPage(BasePage):
     download_link = (By.PARTIAL_LINK_TEXT, "Download this ")
 
-    def get_download_link(self):
+    def _get_download_link_element(self):
         link = self.wait_for_element(self.download_link)
 
-        return link.element.get_attribute("href")
+        return link.element
+
+    def click_download_link(self):
+        return self._get_download_link_element().click()
+
+    def get_download_link(self):
+        return self._get_download_link_element().get_attribute("href")
+
+
+class DocumentDownloadConfirmEmailPage(BasePage):
+    continue_button = CommonPageLocators.CONTINUE_BUTTON
+    email_input = EmailInputElement()
+
+    def input_email_address(self, email_address):
+        self.email_input = email_address
 
 
 class ViewFolderPage(ShowTemplatesPage):

--- a/tests/provider_delivery/test_provider_delivery_email.py
+++ b/tests/provider_delivery/test_provider_delivery_email.py
@@ -8,16 +8,20 @@ from tests.postman import (
 from tests.test_utils import NotificationStatuses, assert_notification_body
 
 
-def test_provider_email_delivery_via_api(client):
+def test_provider_email_delivery_via_api(staging_and_prod_client):
     notification_id = send_notification_via_api(
-        client,
+        staging_and_prod_client,
         config["service"]["templates"]["email"],
         config["user"]["email"],
         "email",
     )
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, NotificationStatuses.DELIVERED],
+        fargs=[
+            staging_and_prod_client,
+            notification_id,
+            NotificationStatuses.DELIVERED,
+        ],
         tries=config["provider_retry_times"],
         delay=config["provider_retry_interval"],
     )

--- a/tests/provider_delivery/test_provider_delivery_sms.py
+++ b/tests/provider_delivery/test_provider_delivery_sms.py
@@ -8,14 +8,21 @@ from tests.postman import (
 from tests.test_utils import NotificationStatuses, assert_notification_body
 
 
-def test_provider_sms_delivery_via_api(client):
+def test_provider_sms_delivery_via_api(staging_and_prod_client):
     notification_id = send_notification_via_api(
-        client, config["service"]["templates"]["sms"], config["user"]["mobile"], "sms"
+        staging_and_prod_client,
+        config["service"]["templates"]["sms"],
+        config["user"]["mobile"],
+        "sms",
     )
 
     notification = retry_call(
         get_notification_by_id_via_api,
-        fargs=[client, notification_id, NotificationStatuses.DELIVERED],
+        fargs=[
+            staging_and_prod_client,
+            notification_id,
+            NotificationStatuses.DELIVERED,
+        ],
         tries=config["provider_retry_times"],
         delay=config["provider_retry_interval"],
     )

--- a/tests/provider_delivery/test_provider_inbound_sms.py
+++ b/tests/provider_delivery/test_provider_inbound_sms.py
@@ -5,9 +5,9 @@ from retry.api import retry_call
 from config import config
 
 
-def test_provider_inbound_sms_delivery_via_api(client):
+def test_provider_inbound_sms_delivery_via_api(staging_and_prod_client):
     unique_content = "inbound test {}".format(uuid.uuid4())
-    client.send_sms_notification(
+    staging_and_prod_client.send_sms_notification(
         phone_number=config["service"]["inbound_number"],
         template_id=config["service"]["templates"]["sms"],
         personalisation={"build_id": unique_content},
@@ -15,16 +15,16 @@ def test_provider_inbound_sms_delivery_via_api(client):
 
     retry_call(
         get_inbound_sms,
-        fargs=[client, unique_content],
+        fargs=[staging_and_prod_client, unique_content],
         tries=config["provider_retry_times"],
         delay=config["provider_retry_interval"],
     )
 
 
-def get_inbound_sms(client, expected_content):
+def get_inbound_sms(staging_and_prod_client, expected_content):
     # this'll raise if the message isn't in the list.
     return next(
         x
-        for x in client.get_received_texts()["received_text_messages"]
+        for x in staging_and_prod_client.get_received_texts()["received_text_messages"]
         if expected_content in x["content"]
     )


### PR DESCRIPTION
https://trello.com/c/rPd2HslH/16-add-functional-test-for-new-document-download-email-confirmation-flow

in the un-auth'd flow we use requests to just download the file and check the contents. If you use selenium to navigate chrome to that page, it'll just load an iframe with the pdf renderer inside so you cant assert if the content of the file is correct.

however, with the auth'd flow it relies on the cookie being set to access the file. requests doesn't have the cookie (only the chrome instances does) and i can't figure out how to get that cookie out, since driver.get_cookies() doesn't return it (it does return the other cookies on path '/').

so, to solve this, instead of getting a pdf, get a csv instead - when chrome renders that, it just shows the text with a minimal html wrapping, which is easy to assert on.

plus some other cleanup best looked at commit-by-commit