### PR TITLE
find submit buttons by looking for a button inside a form

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -61,7 +61,10 @@ class EditTemplatePageLocators(object):
 
 class UploadCsvLocators(object):
     FILE_INPUT = (By.ID, "file")
-    SEND_BUTTON = (By.CSS_SELECTOR, "main [type=submit]")
+    SEND_BUTTON = (
+        By.CSS_SELECTOR,
+        "form button.govuk-button:not(.govuk-button--secondary)",
+    )
     FIRST_NOTIFICATION_AFTER_UPLOAD = (By.CLASS_NAME, "table-row")
 
 
@@ -96,7 +99,10 @@ class InviteUserPageLocators(object):
         By.CSS_SELECTOR,
         "button[aria-controls=folder_permissions]",
     )
-    SEND_INVITATION_BUTTON = (By.CSS_SELECTOR, "main [type=submit]")
+    SEND_INVITATION_BUTTON = (
+        By.CSS_SELECTOR,
+        "form button.govuk-button:not(.govuk-button--secondary)",
+    )
 
 
 class ApiIntegrationPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1107,7 +1107,10 @@ class ManageFolderPage(BasePage):
     delete_link = (By.LINK_TEXT, "Delete this folder")
     name_input = NameInputElement()
     delete_button = (By.NAME, "delete")
-    save_button = (By.CSS_SELECTOR, "main [type=submit]")
+    save_button = (
+        By.CSS_SELECTOR,
+        "form button.govuk-button:not(.govuk-button--secondary)",
+    )
 
     def set_name(self, new_name):
         self.name_input = new_name


### PR DESCRIPTION
they no longer have type=submit in govuk frontend v3.1.0 and higher (as that is implicit for any button without a type inside a form), so we need a different way to find them.

This is safe to merge before any changes to admin.