### PR TITLE
Move rename test to non seeded user

### DIFF
--- a/broadcast_client/broadcast_client.py
+++ b/broadcast_client/broadcast_client.py
@@ -1,7 +1,7 @@
 import urllib.parse
 
-from notifications_python_client.base import BaseAPIClient
 from notifications_python_client.authentication import create_jwt_token
+from notifications_python_client.base import BaseAPIClient
 
 
 class BroadcastClient(BaseAPIClient):

--- a/receive_inbound_sms/application.py
+++ b/receive_inbound_sms/application.py
@@ -1,7 +1,6 @@
 import os
 
-from flask import Flask, jsonify
-from flask import request
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -58,13 +58,22 @@ def test_can_add_and_update_reply_to(driver):
 
 @recordtime
 @pytest.mark.xdist_group(name="registration-flow")
-def test_user_can_add_sms_sender_to_service(driver):
+def test_can_add_and_update_sms_sender_of_service(driver):
     dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
+    sms_sender_page = SmsSenderPage(driver)
 
+    dashboard_page.go_to_dashboard_for_service()
     service_id = dashboard_page.get_service_id()
 
-    sms_sender_page = SmsSenderPage(driver)
+    # add first
+    sms_sender_page.go_to_text_message_senders(service_id)
+    sms_sender_page.click_change_link_for_first_sms_sender()
+    sms_sender_page.insert_sms_sender("first")
+    sms_sender_page.click_save_sms_sender()
+
+    main_content = sms_sender_page.get_sms_senders()
+
+    assert "first \u2002 (default)" in main_content.text
 
     sms_sender_page.go_to_add_text_message_sender(service_id)
     sms_sender_page.insert_sms_sender("second")
@@ -75,28 +84,6 @@ def test_user_can_add_sms_sender_to_service(driver):
     assert "first \u2002 (default)" in main_content.text
     assert "second" in main_content.text
     assert "second \u2002 (default)" not in main_content.text
-
-    dashboard_page.go_to_dashboard_for_service(service_id)
-
-
-@recordtime
-@pytest.mark.xdist_group(name="registration-flow")
-def test_can_update_sms_sender_of_service(driver):
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-
-    service_id = dashboard_page.get_service_id()
-
-    sms_sender_page = SmsSenderPage(driver)
-
-    sms_sender_page.go_to_text_message_senders(service_id)
-    sms_sender_page.click_change_link_for_first_sms_sender()
-    sms_sender_page.insert_sms_sender("first")
-    sms_sender_page.click_save_sms_sender()
-
-    main_content = sms_sender_page.get_sms_senders()
-
-    assert "first \u2002 (default)" in main_content.text
 
     dashboard_page.go_to_dashboard_for_service(service_id)
 

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -10,39 +10,31 @@ from tests.test_utils import (
 )
 
 
+@pytest.fixture(scope="module", autouse=True)
+@recordtime
+def register_user(_driver):
+    # has to use _driver as this is at module level (`driver` fixture is at function level, and just handles taking
+    # the screenshot on failure)
+    do_user_registration(_driver)
+
+
 @recordtime
 @pytest.mark.xdist_group(name="registration-flow")
-def test_registration_and_invite_flow(driver):
-    do_user_registration(driver)
-    do_user_can_add_reply_to_email_to_service(driver)
-    do_user_can_update_reply_to_email_to_service(driver)
-    do_user_can_update_sms_sender_of_service(driver)
-    do_user_can_add_sms_sender_to_service(driver)
+def test_invite_flow(driver):
     do_user_can_invite_someone_to_notify(driver, basic_view=False)
     do_user_can_invite_someone_to_notify(driver, basic_view=True)
 
 
-def do_user_can_update_sms_sender_of_service(driver):
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service()
-
-    service_id = dashboard_page.get_service_id()
-
-    sms_sender_page = SmsSenderPage(driver)
-
-    sms_sender_page.go_to_text_message_senders(service_id)
-    sms_sender_page.click_change_link_for_first_sms_sender()
-    sms_sender_page.insert_sms_sender("first")
-    sms_sender_page.click_save_sms_sender()
-
-    main_content = sms_sender_page.get_sms_senders()
-
-    assert "first \u2002 (default)" in main_content.text
-
-    dashboard_page.go_to_dashboard_for_service(service_id)
+@recordtime
+@pytest.mark.xdist_group(name="registration-flow")
+def test_can_add_and_update_reply_to(driver):
+    do_user_can_add_reply_to_email_to_service(driver)
+    do_user_can_update_reply_to_email_to_service(driver)
 
 
-def do_user_can_add_sms_sender_to_service(driver):
+@recordtime
+@pytest.mark.xdist_group(name="registration-flow")
+def test_user_can_add_sms_sender_to_service(driver):
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service()
 
@@ -59,5 +51,27 @@ def do_user_can_add_sms_sender_to_service(driver):
     assert "first \u2002 (default)" in main_content.text
     assert "second" in main_content.text
     assert "second \u2002 (default)" not in main_content.text
+
+    dashboard_page.go_to_dashboard_for_service(service_id)
+
+
+@recordtime
+@pytest.mark.xdist_group(name="registration-flow")
+def test_can_update_sms_sender_of_service(driver):
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service()
+
+    service_id = dashboard_page.get_service_id()
+
+    sms_sender_page = SmsSenderPage(driver)
+
+    sms_sender_page.go_to_text_message_senders(service_id)
+    sms_sender_page.click_change_link_for_first_sms_sender()
+    sms_sender_page.insert_sms_sender("first")
+    sms_sender_page.click_save_sms_sender()
+
+    main_content = sms_sender_page.get_sms_senders()
+
+    assert "first \u2002 (default)" in main_content.text
 
     dashboard_page.go_to_dashboard_for_service(service_id)

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -1,6 +1,12 @@
 import pytest
 
-from tests.pages import DashboardPage, SmsSenderPage
+from config import config
+from tests.pages import (
+    ChangeName,
+    DashboardPage,
+    ServiceSettingsPage,
+    SmsSenderPage,
+)
 from tests.test_utils import (
     do_user_can_add_reply_to_email_to_service,
     do_user_can_invite_someone_to_notify,
@@ -75,3 +81,37 @@ def test_can_update_sms_sender_of_service(driver):
     assert "first \u2002 (default)" in main_content.text
 
     dashboard_page.go_to_dashboard_for_service(service_id)
+
+
+@recordtime
+@pytest.mark.xdist_group(name="registration-flow")
+def test_change_service_name(driver):
+    old_name = config["service_name"]
+    new_name = f"{old_name} (renamed)"
+
+    dashboard_page = DashboardPage(driver)
+    service_settings = ServiceSettingsPage(driver)
+    change_name = ChangeName(driver)
+
+    # make sure the service is actually named what we expect
+    assert dashboard_page.get_service_name() == old_name
+
+    dashboard_page.go_to_dashboard_for_service()
+    dashboard_page.click_settings()
+
+    service_settings.go_to_change_service_name()
+
+    change_name.enter_new_name(new_name)
+    change_name.click_save()
+
+    dashboard_page.go_to_dashboard_for_service()
+    assert dashboard_page.get_service_name() == new_name
+
+    # change the name back. it's probably not essential that this happens
+    dashboard_page.click_settings()
+    service_settings.go_to_change_service_name()
+    change_name.enter_new_name(old_name)
+    change_name.click_save()
+
+    dashboard_page.go_to_dashboard_for_service()
+    assert dashboard_page.get_service_name() == old_name

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -7,6 +7,7 @@ from tests.pages import (
     ServiceSettingsPage,
     SmsSenderPage,
 )
+from tests.pages.rollups import sign_in
 from tests.test_utils import (
     do_user_can_add_reply_to_email_to_service,
     do_user_can_invite_someone_to_notify,
@@ -24,11 +25,28 @@ def register_user(_driver):
     do_user_registration(_driver)
 
 
+def _sign_in_again(driver):
+    # sign back in as the original service user
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.sign_out()
+    dashboard_page.wait_until_url_is(config["notify_admin_url"])
+
+    sign_in(driver, account_type="normal")
+
+    service_id = dashboard_page.get_service_id()
+    dashboard_page.go_to_dashboard_for_service(service_id)
+
+
 @recordtime
 @pytest.mark.xdist_group(name="registration-flow")
 def test_invite_flow(driver):
     do_user_can_invite_someone_to_notify(driver, basic_view=False)
+
+    _sign_in_again(driver)
+
     do_user_can_invite_someone_to_notify(driver, basic_view=True)
+
+    _sign_in_again(driver)
 
 
 @recordtime

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -18,13 +18,11 @@ from tests.functional.preview_and_dev.consts import (
 )
 from tests.pages import (
     ApiIntegrationPage,
-    ChangeName,
     DashboardPage,
     EditEmailTemplatePage,
     InviteUserPage,
     ManageFolderPage,
     PreviewLetterPage,
-    ServiceSettingsPage,
     ShowTemplatesPage,
     TeamMembersPage,
     UploadCsvPage,
@@ -543,34 +541,6 @@ def test_template_folder_permissions(driver, login_seeded_user):
         manage_folder_page = ManageFolderPage(driver)
         manage_folder_page.delete_folder()
         manage_folder_page.confirm_delete_folder()
-
-
-@pytest.mark.xdist_group(name="seeded-user")
-def test_change_service_name(driver, login_seeded_user):
-    new_name = "Functional Tests {}".format(uuid.uuid4())
-    dashboard_page = DashboardPage(driver)
-    # make sure the service is actually named what we expect
-    assert dashboard_page.get_service_name() == config["service"]["name"]
-    dashboard_page.go_to_dashboard_for_service(config["service"]["id"])
-    dashboard_page.click_settings()
-    service_settings = ServiceSettingsPage(driver)
-    change_name = ChangeName(driver)
-    change_name.go_to_change_service_name(config["service"]["id"])
-    change_name.enter_new_name(new_name)
-    change_name.click_save()
-    service_settings.check_service_name(new_name)
-
-    dashboard_page.go_to_dashboard_for_service(config["service"]["id"])
-    assert dashboard_page.get_service_name() == new_name
-
-    # change the name back
-    change_name.go_to_change_service_name(config["service"]["id"])
-    change_name.enter_new_name(config["service"]["name"])
-    change_name.click_save()
-    service_settings.check_service_name(config["service"]["name"])
-
-    dashboard_page.go_to_dashboard_for_service(config["service"]["id"])
-    assert dashboard_page.get_service_name() == config["service"]["name"]
 
 
 def _check_status_of_notification(

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -151,6 +151,7 @@ class SmsSenderLocators(object):
 
 class ServiceSettingsLocators(object):
     SERVICE_NAME = (By.CSS_SELECTOR, ".navigation-service-name")
+    CHANGE_SERVICE_NAME_LINK = (By.CSS_SELECTOR, "tr:nth-child(1) > td:nth-child(3) a")
 
 
 class ChangeNameLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -901,12 +901,11 @@ class SendOneRecipient(BasePage):
 
 
 class ServiceSettingsPage(BasePage):
-    def check_service_name(self, expected_name):
-        name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
-        if name.element.text == expected_name:
-            return True
-        else:
-            raise ValueError("Service name not changed succesfully")
+    def go_to_change_service_name(self):
+        element = self.wait_for_element(
+            ServiceSettingsLocators.CHANGE_SERVICE_NAME_LINK
+        )
+        element.click()
 
 
 class ChangeName(BasePage):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -221,8 +221,6 @@ def do_user_can_invite_someone_to_notify(driver, basic_view):
     assert dashboard_page.get_service_name() == config["service_name"]
     if basic_view:
         is_basic_view(dashboard_page)
-        dashboard_page.sign_out()
-        dashboard_page.wait_until_url_is(config["notify_admin_url"])
     else:
         is_view_for_all_permissions(dashboard_page)
 


### PR DESCRIPTION
if this test fails for whatever reason, it might leave the service in an unusual state (with the wrong service name). lots of tests check the service name to assert they're logged in to the correct account, and thus, will fail unless we manually rename the service back.

moving this test from the seeded service to the test registration service means we can not worry as much if the test fails, as no future test runs will look at this service.


this wasn't quite a lift-and-shift as i needed to tweak things because we don't know the service id, so now the change name test clicks the button in the service settings rather than just navigating to the URL - this is probably a better test anyway.