### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ Flask>=0.11.1
 Flask-Cache==0.13.1
 requests==2.28.0
 beautifulsoup4>=4.5.1
-flake8==6.0.0
-isort==5.12.0
+flake8==6.0.0  # Also update `.pre-commit-config.yaml` if this changes
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 pytest==7.1.3
 retry==0.9.2
 selenium==4.6.0
 notifications-python-client==6.4.1
 pytest-xdist==3.0.2
-black==22.10.0
+black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-Cache==0.13.1
 requests==2.28.0
 beautifulsoup4>=4.5.1
 flake8==6.0.0
-isort==5.10.1
+isort==5.12.0
 pytest==7.1.3
 retry==0.9.2
 selenium==4.6.0


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.