### PR TITLE
Remove passing of `BUILD_ID` by environment variable

### DIFF
--- a/tests/postman.py
+++ b/tests/postman.py
@@ -1,5 +1,3 @@
-import os
-
 from notifications_python_client.errors import HTTPError
 
 from config import config
@@ -7,8 +5,7 @@ from tests.test_utils import RetryException, create_temp_csv
 
 
 def send_notification_via_api(client, template_id, to, message_type):
-    build_id = os.getenv("BUILD_ID", "No build id")
-    personalisation = {"build_id": build_id}
+    personalisation = {"build_id": "No build id"}
 
     if message_type == "sms":
         resp_json = client.send_sms_notification(to, template_id, personalisation)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,8 +37,6 @@ logging.basicConfig(
     filename="./logs/test_run_{}.log".format(datetime.utcnow()), level=logging.INFO
 )
 
-build_id = os.getenv("BUILD_ID", "No build id")
-
 default = " (default)"
 
 
@@ -54,7 +52,7 @@ def create_temp_csv(fields):
     directory_name = tempfile.mkdtemp()
     csv_filename = "{}-sample.csv".format(uuid.uuid4())
     csv_file_path = os.path.join(directory_name, csv_filename)
-    fields.update({"build_id": build_id})
+    fields.update({"build_id": "No build id"})
     with open(csv_file_path, "w") as csv_file:
         csv_writer = csv.DictWriter(csv_file, fieldnames=fields.keys())
         csv_writer.writeheader()


### PR DESCRIPTION
My rough recollection/assumption is that we used to pass a jenkins build ID into the functional tests whenever we did a deployment. We stopped doing that when we moved to concourse so we no longer appear to be passing `BUILD_ID` as an environment variable anymore (I've searched the creds repo and also the concourse pipelines).

I looked into whether we can just remove the `build_id` completely, ie from the notify templates themselves if we are just passing 'No build id' all the time. However it appears that we do indeed use that placeholder, for example we use it to pass in a link to document download files in:
https://github.com/alphagov/notifications-functional-tests/blob/main/tests/document_download/preview_and_dev/test_document_download.py#L24

Therefore we can't remove the build_id completely, but I think it is still nice to remove a couple of lines of code, in particular for the complexity when you have to wonder if the build_id is being provided by the environment ever or not.