### PR TITLE
Set `NOTIFY_ECS_ORIGIN` environment variable to force HTTP requests to go to ECS, not GOV.UK PaaS

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,13 +50,6 @@ urls = {
         "admin": "https://www.notify.works",
         "govuk_alerts": "https://www.integration.publishing.service.gov.uk/alerts",
     },
-    # ECS apps are being deployed piecemeal and at present there are no api or govuk_alerts
-    # urls for the ecs-preview environment, so for now we will use those of the preview env
-    "ecs-preview": {
-        "api": "https://api.notify.works",
-        "admin": "https://www-ecs.notify.works",
-        "govuk_alerts": "https://www.integration.publishing.service.gov.uk/alerts",
-    },
     "staging": {
         "api": "https://api.staging-notify.works",
         "admin": "https://www.staging-notify.works",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 pytest==7.1.3
 retry==0.9.2
 selenium==4.6.0
+selenium-wire==5.1.0
 notifications-python-client==6.4.1
 pytest-xdist==3.0.2
 black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,0 +1,23 @@
+import os
+
+from notifications_python_client import NotificationsAPIClient
+
+
+# This allows us to set an additional HTTP header with every HTTP request
+# made by our python Notify API client. This extra header can be
+# toggled on and if based on the NOTIFY_ECS_ORIGIN environment variable
+# and will send requests to our ECS infrastructure instead of our PaaS
+# infrastructure by using the special header required by our Lambda function
+# https://github.com/alphagov/notifications-aws/tree/main/terraform/modules/migrate-traffic-to-ecs-lambda
+def ecs_override_generate_headers(self, api_token):
+    headers = self.original_generate_headers(api_token)
+    if os.getenv("NOTIFY_ECS_ORIGIN"):
+        headers["x-notify-ecs-origin"] = "true"
+    return headers
+
+
+FunctionalTestsAPIClient = NotificationsAPIClient
+FunctionalTestsAPIClient.original_generate_headers = (
+    FunctionalTestsAPIClient.generate_headers
+)
+FunctionalTestsAPIClient.generate_headers = ecs_override_generate_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
+from seleniumwire import webdriver as selenium_wire_webdriver
 
 from broadcast_client.broadcast_client import BroadcastClient
 from config import config, setup_shared_config
@@ -52,8 +53,14 @@ def _driver(request, download_directory):
         log_path="./logs/chrome_browser.log", service_args=["--verbose"]
     )
 
-    driver = webdriver.Chrome(service=service, options=options)
+    driver = selenium_wire_webdriver.Chrome(service=service, options=options)
     driver.set_window_size(1280, 720)
+
+    def interceptor(request):
+        request.headers["x-notify-ecs-origin"] = "true"
+
+    if os.getenv("NOTIFY_ECS_ORIGIN"):
+        driver.request_interceptor = interceptor
 
     driver.delete_all_cookies()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from notifications_python_client import NotificationsAPIClient
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 
 from broadcast_client.broadcast_client import BroadcastClient
 from config import config, setup_shared_config
+from tests.client import FunctionalTestsAPIClient
 from tests.pages.pages import HomePage
 from tests.pages.rollups import sign_in, sign_in_email_auth
 
@@ -93,7 +93,7 @@ def login_seeded_user(_driver):
 
 @pytest.fixture(scope="module")
 def client_live_key():
-    client = NotificationsAPIClient(
+    client = FunctionalTestsAPIClient(
         base_url=config["notify_api_url"], api_key=config["service"]["api_live_key"]
     )
     return client
@@ -101,7 +101,7 @@ def client_live_key():
 
 @pytest.fixture(scope="module")
 def client_test_key():
-    client = NotificationsAPIClient(
+    client = FunctionalTestsAPIClient(
         base_url=config["notify_api_url"], api_key=config["service"]["api_test_key"]
     )
     return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,6 @@ def download_directory(tmp_path_factory):
 
 @pytest.fixture(scope="module")
 def _driver(request, download_directory):
-    http_proxy = os.getenv("HTTP_PROXY")
-
     options = webdriver.chrome.options.Options()
     options.add_argument("--no-sandbox")
     options.add_argument("user-agent=Selenium")
@@ -49,9 +47,6 @@ def _driver(request, download_directory):
 
     if not request.config.getoption("--no-headless"):
         options.add_argument("--headless")
-
-    if http_proxy is not None and http_proxy != "":
-        options.add_argument("--proxy-server={}".format(http_proxy))
 
     service = ChromeService(
         log_path="./logs/chrome_browser.log", service_args=["--verbose"]

--- a/tests/document_download/preview_and_dev/test_document_download.py
+++ b/tests/document_download/preview_and_dev/test_document_download.py
@@ -1,3 +1,4 @@
+import os
 import re
 from io import BytesIO
 from urllib.parse import urlparse
@@ -68,7 +69,11 @@ def test_document_upload_and_download(driver, client_live_key):
     download_page = DocumentDownloadPage(driver)
     document_url = download_page.get_download_link()
 
-    downloaded_document = requests.get(document_url)
+    headers = {}
+    if os.getenv("NOTIFY_ECS_ORIGIN"):
+        headers = {"x-notify-ecs-origin": "true"}
+
+    downloaded_document = requests.get(document_url, headers=headers)
 
     assert downloaded_document.text == "foo-bar-baz"
 

--- a/tests/functional/preview_and_dev/test_inbound_sms.py
+++ b/tests/functional/preview_and_dev/test_inbound_sms.py
@@ -9,6 +9,7 @@ Test:
 Test:
     look at inbox page - assert that the new message is in the conversation
 """
+import os
 from datetime import datetime
 from urllib.parse import quote_plus
 
@@ -33,6 +34,10 @@ def inbound_sms():
         "DateRecieved": quote_plus(datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")),
     }
 
+    headers = {}
+    if os.getenv("NOTIFY_ECS_ORIGIN"):
+        headers = {"x-notify-ecs-origin": "true"}
+
     response = requests.post(
         config["notify_api_url"] + "/notifications/sms/receive/mmg",
         json=mmg_inbound_body,
@@ -40,6 +45,7 @@ def inbound_sms():
             config["mmg_inbound_sms"]["username"],
             config["mmg_inbound_sms"]["password"],
         ),
+        headers=headers,
     )
     response.raise_for_status()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,12 +7,12 @@ import tempfile
 import uuid
 from datetime import datetime
 
-from notifications_python_client.notifications import NotificationsAPIClient
 from retry import retry
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 
 from config import config, generate_unique_email
+from tests.client import FunctionalTestsAPIClient
 from tests.pages import (
     AddServicePage,
     DashboardPage,
@@ -400,7 +400,9 @@ def _assert_one_off_email_filled_in_properly(
 
 
 def get_notification_by_to_field(template_id, api_key, sent_to, statuses=None):
-    client = NotificationsAPIClient(base_url=config["notify_api_url"], api_key=api_key)
+    client = FunctionalTestsAPIClient(
+        base_url=config["notify_api_url"], api_key=api_key
+    )
     resp = client.get("v2/notifications")
     for notification in resp["notifications"]:
         t_id = notification["template"]["id"]


### PR DESCRIPTION
https://trello.com/c/OzXPapgY/199-allow-configuration-of-functional-tests-to-include-http-header-to-divert-traffic-to-ecs

Best reviewed commit by commit

If you set the `NOTIFY_ECS_ORIGIN` environment variable, then because of our AWS Lambda function (https://github.com/alphagov/notifications-aws/tree/main/terraform/modules/migrate-traffic-to-ecs-lambda), you can make the functional tests run against our ECS infra, not our PaaS infra.

After we've migrated off the PaaS, we can remove all of this code.

To test this, start by checking you can run the functional tests against our preview PaaS environment from your local. You may need to first copy the credentials from `credentials/functional-tests/preview` into `environment_sh`. Then you can:

```
source environment_preview.sh
pytest tests/functional/preview_and_dev
```

These should go green.

Then run
```
NOTIFY_ECS_ORIGIN=true pytest tests/functional/preview_and_dev
```

Here you should see all failures. This is because our ECS infrastructure doesn't actually work yet... So failures are actually good because a failure means you are getting a change in behaviour when passing the environment variable...

If you want confidence that requests are indeed going to ECS, you can look at the metrics and monitoring for our ECS apps and see an uptick in memory and CPU when you run the functional tests, and also some errors in the logs too.