### PR TITLE
Update xpath targeting folder paths

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -627,7 +627,7 @@ class EditEmailTemplatePage(BasePage):
     def folder_path_item(folder_name):
         return (
             By.XPATH,
-            "//a[contains(@class,'folder-heading-folder') and contains(text(), '{}')]".format(
+            "//a[contains(@class,'folder-heading-folder')]/text()[contains(.,'{}')]/..".format(
                 folder_name
             ),
         )


### PR DESCRIPTION
The current xpath targets links with the 'folder-heading-folder' class and text content matching a folder name.

These links have been changed (in https://github.com/alphagov/notifications-admin/pull/4688) to include an `<svg>` element for their folder icon. This means you can't use `contains` on them directly as they have more than one child node.

These changes make the xpath target the value of text nodes that are children of the link instead. XPath is hard so here's an explanation:
- `//` targets all nodes in the document
- `a[contains(@class, 'folder-heading-folder')` filters that into just the nodes which are links whose 'class' attribute contains the string 'folder-heading-folder'
- `/text()` gets all the text nodes which are children of the selected links
- `[contains(.,{})]` filters those nodes to any whose value contains `{}`, which Python will replace with the folder name

## How do I test this?

1. go to the page for a folder, preferably a few levels down
2. open devtools and put the xpath into the search box in the 'elements' tab (which can take xpath)
3. change the text to match each item in the path of the h1 and see if it works