### PR TITLE
Add fixtures for staging provider functional tests

### DIFF
--- a/db_fixtures/staging.sql.j2
+++ b/db_fixtures/staging.sql.j2
@@ -1,5 +1,5 @@
 /*
-These fixtures currently only cover the core Notify functional tests. We still need to add the fixtures for the document download functional tests and the provider tests.
+These fixtures cover the core functional tests and the document download functional tests. The fixtures for the provider functional tests are further down.
 */
 
 COPY users (id, name, email_address, created_at, updated_at, _password, mobile_number, password_changed_at, logged_in_at, failed_login_count, state, platform_admin, current_session_id, auth_type, email_access_validated_at) FROM stdin;
@@ -101,4 +101,68 @@ COPY permissions (id, service_id, user_id, permission, created_at) FROM stdin;
 57fe6bb5-92b8-4e7a-8a4e-ef9344555c1f	1e7226d5-e216-4eb0-ae4b-3caa9febd4c4	19c5f2e9-c36e-4ebe-b575-917389281e74	send_letters	2019-03-25 15:02:40.881388
 59975136-b589-4ece-bd39-5ce78704c4a9	1e7226d5-e216-4eb0-ae4b-3caa9febd4c4	19c5f2e9-c36e-4ebe-b575-917389281e74	manage_api_keys	2019-03-25 15:02:40.881911
 7a745e19-d51e-497d-bfea-b6b898ab20c9	1e7226d5-e216-4eb0-ae4b-3caa9febd4c4	19c5f2e9-c36e-4ebe-b575-917389281e74	view_activity	2019-03-25 15:02:40.882341
+\.
+
+/*
+These fixtures cover the provider functional tests
+*/
+
+COPY users (id, name, email_address, created_at, updated_at, _password, mobile_number, password_changed_at, logged_in_at, failed_login_count, state, platform_admin, current_session_id, auth_type, email_access_validated_at) FROM stdin;
+cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	Functional Tests - Providers	notify-tests-staging+provider-tests@digital.cabinet-office.gov.uk	2019-03-25 14:48:38.719334	2019-03-25 14:50:58.826605	{{ sms_auth_user_password_hash }}	+447481342436	2019-03-25 14:48:38.71801	2019-03-25 14:50:58.796995	0	active	f	23ca4bbf-347f-44a7-b998-142bca2fa991	sms_auth	NOW()
+\.
+
+COPY services (id, name, created_at, updated_at, active, restricted, email_from, created_by_id, version, organisation_type, prefix_sms, crown, rate_limit, contact_link, count_as_live, letter_message_limit, sms_message_limit, email_message_limit, has_active_go_live_request) FROM stdin;
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	Functional Tests - Providers Staging	2019-03-25 15:02:40.869192	2019-03-25 15:35:17.203589	t	t	functional.tests.provider	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	5	central	t	t	3000	e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5	t	50	50	50	f
+\.
+
+COPY service_permissions (service_id, permission, created_at) FROM stdin;
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	sms	2019-03-25 15:02:40.883347
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	email	2019-03-25 15:02:40.883352
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	letter	2019-03-25 15:02:40.883354
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	international_sms	2019-03-25 15:02:40.883356
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	email_auth	2019-03-25 15:10:35.734382
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	inbound_sms	2019-03-25 15:20:26.075574
+8035fcbf-f064-4dda-b8f7-3fffa3478f30	edit_folder_permissions	2019-03-25 15:35:17.196132
+\.
+
+COPY user_to_service (user_id, service_id) FROM stdin;
+cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	8035fcbf-f064-4dda-b8f7-3fffa3478f30
+\.
+
+COPY permissions (id, service_id, user_id, permission, created_at) FROM stdin;
+19477836-8dd2-41ca-9bbf-29d8053d43e1	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	manage_users	2019-03-25 15:02:40.878539
+25562d32-dc29-49be-9bc5-664414307af2	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	manage_templates	2019-03-25 15:02:40.879226
+306795a6-ecac-435d-b9a4-d47cc2a49a13	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	manage_settings	2019-03-25 15:02:40.879746
+4e18b7c0-3d25-4755-a78f-9d5e562459b4	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	send_texts	2019-03-25 15:02:40.880256
+5e86faae-0d12-412f-a430-2400f955b705	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	send_emails	2019-03-25 15:02:40.880833
+67fe6bb5-92b8-4e7a-8a4e-ef9344555c16	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	send_letters	2019-03-25 15:02:40.881388
+79975136-b589-4ece-bd39-5ce78704c4a7	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	manage_api_keys	2019-03-25 15:02:40.881911
+8a745e19-d51e-497d-bfea-b6b898ab20c8	8035fcbf-f064-4dda-b8f7-3fffa3478f30	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	view_activity	2019-03-25 15:02:40.882341
+\.
+
+COPY templates (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, hidden) FROM stdin;
+365c76fe-286a-4bc3-8048-e4e47af5bc96	Functional Tests - Provider Email Template with Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Build id: ((build_id)).	8035fcbf-f064-4dda-b8f7-3fffa3478f30	Functional Tests - CSV Email	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	f	normal	f
+1c2d3b7b-9b10-49f6-9e4b-65ac4ad71e92	Functional Tests - Provider SMS Template with build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Build id: ((build_id)).	8035fcbf-f064-4dda-b8f7-3fffa3478f30	\N	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	f	normal	f
+\.
+
+COPY templates_history (id, name, template_type, created_at, updated_at, content, service_id, subject, created_by_id, version, archived, process_type, hidden) FROM stdin;
+365c76fe-286a-4bc3-8048-e4e47af5bc96	Functional Tests - Provider Email Template with Build ID	email	2019-03-25 15:23:07.172674	\N	The quick brown fox jumped over the lazy dog. Build id: ((build_id)).	8035fcbf-f064-4dda-b8f7-3fffa3478f30	Functional Tests - CSV Email	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	f	normal	f
+1c2d3b7b-9b10-49f6-9e4b-65ac4ad71e92	Functional Tests - Provider SMS Template with build ID	sms	2019-03-25 15:24:14.907439	\N	The quick brown fox jumped over the lazy dog. Build id: ((build_id)).	8035fcbf-f064-4dda-b8f7-3fffa3478f30	\N	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	f	normal	f
+\.
+
+COPY api_keys (id, name, secret, service_id, created_at, created_by_id, version, key_type) FROM stdin;
+b1557954-2458-4c1e-ad19-50f6ef69e628	Staging provider functional test key (team)	{{ staging_provider_functional_test_team_api_key_secret }}	8035fcbf-f064-4dda-b8f7-3fffa3478f30	2019-03-25 15:07:17.182987	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	team
+\.
+
+COPY api_keys_history (id, name, secret, service_id, created_at, created_by_id, version, key_type) FROM stdin;
+b1557954-2458-4c1e-ad19-50f6ef69e628	Staging provider functional test key (team)	{{ staging_provider_functional_test_team_api_key_secret }}	8035fcbf-f064-4dda-b8f7-3fffa3478f30	2019-03-25 15:07:17.182987	cc2fe4d4-df6a-4a3b-82db-98fdcc54ea67	1	team
+\.
+
+COPY inbound_numbers (id, number, provider, service_id, active, created_at, updated_at) FROM stdin;
+b367511d-4105-475c-9063-88286bec0f47	07491163046	mmg	8035fcbf-f064-4dda-b8f7-3fffa3478f30	t	2018-05-22 13:16:05.227575	2018-05-22 13:16:23.965573
+\.
+
+COPY service_whitelist (id, service_id, recipient_type, recipient, created_at) FROM stdin;
+47dced7d-1f6b-4875-aff4-b817536cef83	8035fcbf-f064-4dda-b8f7-3fffa3478f30	mobile	07491163032	2018-05-22 13:39:22.048113
+f9974219-489b-40fa-a007-691e7a22aea3	8035fcbf-f064-4dda-b8f7-3fffa3478f30	mobile	07491163046	2018-05-22 13:39:22.04952
 \.


### PR DESCRIPTION
Mostly copied from the core fixtures further up in the file and then adapted to put in the correct IDs for the provider tests

Relies on https://github.com/alphagov/notifications-credentials/pull/348

You can review this by 
- pulling the merged version of the credentials and running `make generate-staging-db-fixtures`
- having a general eyeball of the fixtures

<img width="882" alt="image" src="https://github.com/alphagov/notifications-functional-tests/assets/7228605/2e90b5e3-9488-479d-a6e5-04cedecfe639">
