### PR TITLE
Remove references to `ecs-preview` env

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,7 +69,7 @@ def setup_shared_config():
     """
     env = os.environ["ENVIRONMENT"].lower()
 
-    if env not in {"dev", "preview", "ecs-preview", "staging", "live"}:
+    if env not in {"dev", "preview", "staging", "live"}:
         pytest.fail('env "{}" not one of dev, preview, staging, live'.format(env))
 
     config.update(


### PR DESCRIPTION
We removed the config for `ecs-preview` in 214d61bdcbe8ce4a707cae58f6866b8df5850141 so we no longer need to include it in the list of possible environments.