### PR TITLE
Add Pytest marker for the broadcast tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     template_preview: mark a tests to run for template-preview builds.
     antivirus: mark a test to run for antivirus builds.
+    broadcast: mark tests for broadcasts.

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -26,6 +26,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.broadcast
 @pytest.mark.xdist_group(name="broadcasts")
 def test_prepare_broadcast_with_new_content(driver):
     sign_in(driver, account_type="broadcast_create_user")
@@ -96,6 +97,7 @@ def test_prepare_broadcast_with_new_content(driver):
 
 
 @recordtime
+@pytest.mark.broadcast
 @pytest.mark.xdist_group(name="broadcasts")
 def test_prepare_broadcast_with_template(driver):
     sign_in(driver, account_type="broadcast_create_user")
@@ -147,6 +149,7 @@ def test_prepare_broadcast_with_template(driver):
 
 
 @recordtime
+@pytest.mark.broadcast
 @pytest.mark.xdist_group(name="broadcasts")
 def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))
@@ -185,6 +188,7 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
 
 
 @recordtime
+@pytest.mark.broadcast
 @pytest.mark.xdist_group(name="broadcasts")
 def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow() - timedelta(hours=1))


### PR DESCRIPTION
We have Pytest markers so that we can run the antivirus and template-preview tests. This adds a new marker, broadcast, which we will use to _avoid_ running the broadcast tests for the ECS apps using `pytest -m "not broadcast"`. We are not creating the broadcast worker in ECS, so the broadcast tests will always fail and add extra running time.