### PR TITLE
Seeded user per test

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Parallel tests executed using the same user type can cause race conditions and i
 We use the following annotations on test methods to define the groups:
 
 ```python
-@pytest.mark.xdist_group(name="seeded-user")
 @pytest.mark.xdist_group(name="registration-flow")
 @pytest.mark.xdist_group(name="api-client")
 @pytest.mark.xdist_group(name="seeded-email")

--- a/config.py
+++ b/config.py
@@ -94,6 +94,10 @@ def setup_preview_dev_config():
                 "password": os.environ["FUNCTIONAL_TEST_PASSWORD"],
                 "mobile": os.environ["TEST_NUMBER"],
             },
+            "api_auth": {
+                "client_id": "notify-functional-tests",
+                "secret": os.environ["FUNCTIONAL_TESTS_API_AUTH_SECRET"],
+            },
             "notify_service_api_key": os.environ["NOTIFY_SERVICE_API_KEY"],
             "broadcast_service": {
                 "id": os.environ["BROADCAST_SERVICE_ID"],

--- a/environment_local.sh
+++ b/environment_local.sh
@@ -16,6 +16,7 @@ export FUNCTIONAL_TESTS_SERVICE_NAME='Functional Tests'
 export FUNCTIONAL_TESTS_ORGANISATION_ID='e6e6ce48-f634-4ebf-af7b-c70fdf16cbd5'
 export FUNCTIONAL_TESTS_SERVICE_API_KEY='functional_tests_research_live_key-34b725f0-1f47-49bc-a9f5-aa2a84587c53-846a8975-9e37-4530-ba2b-6ed53819b78d'
 export FUNCTIONAL_TESTS_SERVICE_API_TEST_KEY='functional_tests_research_test_key-34b725f0-1f47-49bc-a9f5-aa2a84587c53-ffaf2dec-e7da-4fbe-bcc7-ce6ad51e3b5e'
+export FUNCTIONAL_TESTS_API_AUTH_SECRET='functional-tests-secret-key'
 
 export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO='notify-tests-preview+local-reply-to@digital.cabinet-office.gov.uk'
 export FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER=07700900500

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ jinja2-cli==0.8.2
 pillow==10.0.0
 pyzbar==0.1.9
 pdf2image==1.16.3
+filelock==3.12.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,9 +89,10 @@ def login_user(_driver):
     sign_in_email_auth(_driver)
 
 
-@pytest.fixture(scope="module")
-def login_seeded_user(_driver):
-    sign_in(_driver, account_type="seeded")
+@pytest.fixture(scope="function")
+def login_seeded_user(_driver, request: pytest.FixtureRequest):
+    _driver.delete_all_cookies()
+    sign_in(_driver, account_type="seeded", test_name=request.node.name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -1,6 +1,9 @@
 import pytest
+import requests
+from filelock import FileLock
+from notifications_python_client.authentication import create_jwt_token
 
-from config import setup_preview_dev_config
+from config import config, setup_preview_dev_config
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -9,3 +12,74 @@ def preview_dev_config():
     Setup
     """
     setup_preview_dev_config()
+
+
+def _create_seeded_users_via_notify_api(test_names):
+    from tests.pages.rollups import get_email_and_password, get_mobile_number
+
+    user_info = []
+    for test_name in test_names:
+        service_id = config["service"]["id"]
+        organisation_id = config["service"]["organisation_id"]
+        email_address, password = get_email_and_password(account_type="seeded", test_name=test_name)
+        mobile_number = get_mobile_number(account_type="seeded")
+        auth_type = "sms_auth"
+        state = "active"
+        permissions = [
+            "manage_api_keys",
+            "manage_settings",
+            "manage_templates",
+            "manage_users",
+            "send_emails",
+            "send_letters",
+            "send_texts",
+            "view_activity",
+        ]
+
+        user_info.append(
+            {
+                "name": f"Preview admin tests user - {test_name}",
+                "service_id": service_id,
+                "organisation_id": organisation_id,
+                "email_address": email_address,
+                "password": password,
+                "mobile_number": mobile_number,
+                "auth_type": auth_type,
+                "state": state,
+                "permissions": permissions,
+            }
+        )
+
+    api_token = create_jwt_token(config["api_auth"]["secret"], config["api_auth"]["client_id"])
+    headers = {
+        "Content-type": "application/json",
+        "Authorization": f"Bearer {api_token}",
+    }
+
+    response = requests.put(config["notify_api_url"] + "/__testing/functional/users", json=user_info, headers=headers)
+    assert response.status_code == 201
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_seeded_users(request: pytest.FixtureRequest, preview_dev_config, tmp_path_factory, worker_id):
+    """Finds all tests that use the `login_seeded_user` fixture, and (if necessary) creates seeded users
+    for those tests.
+    """
+    # get the temp directory shared by all workers
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+
+    unique_seeder_user_tests = {
+        node.name
+        for node in request.session.items
+        if any(fixturename == "login_seeded_user" for fixturename in node.fixturenames)
+    }
+
+    if worker_id == "master":
+        _create_seeded_users_via_notify_api(test_names=unique_seeder_user_tests)
+
+    else:
+        create_api_users_file = root_tmp_dir / "create-seeded-users"
+        with FileLock(str(create_api_users_file) + ".lock"):
+            if not create_api_users_file.is_file():
+                create_api_users_file.touch()
+                _create_seeded_users_via_notify_api(test_names=unique_seeder_user_tests)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -103,7 +103,7 @@ def test_prepare_broadcast_with_template(driver):
     sign_in(driver, account_type="broadcast_create_user")
 
     go_to_templates_page(driver, service="broadcast_service")
-    template_name = "test broadcast" + str(uuid.uuid4())
+    template_name = f"test broadcast {uuid.uuid4()}"
     content = "This is a test only."
     create_broadcast_template(driver, name=template_name, content=content)
 

--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -23,9 +23,8 @@ def test_email_auth(driver):
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
-def test_reset_forgotten_password(driver):
-    email, password = get_email_and_password(account_type="seeded")
+def test_reset_forgotten_password(driver, request):
+    email, password = get_email_and_password(account_type="seeded", test_name=request.node.name)
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
     assert sign_in_page.is_current()

--- a/tests/functional/preview_and_dev/test_inbound_sms.py
+++ b/tests/functional/preview_and_dev/test_inbound_sms.py
@@ -58,7 +58,6 @@ def test_inbound_api(inbound_sms, client_live_key):
     next(x for x in client_live_key.get_received_texts()["received_text_messages"] if x["content"] == inbound_sms)
 
 
-@pytest.mark.xdist_group(name="seeded-user")
 def test_inbox_page(inbound_sms, driver, login_seeded_user):
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(config["service"]["id"])

--- a/tests/functional/preview_and_dev/test_org_invite.py
+++ b/tests/functional/preview_and_dev/test_org_invite.py
@@ -1,7 +1,5 @@
 import uuid
 
-import pytest
-
 from config import config, generate_unique_email
 from tests.pages import (
     DashboardPage,
@@ -14,7 +12,6 @@ from tests.test_utils import do_verify, get_link, recordtime
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_org_invite(driver, login_seeded_user):
     org_dashboard_page = OrganisationDashboardPage(driver)
     org_dashboard_page.go_to_dashboard_for_org(config["service"]["organisation_id"])

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -52,7 +52,6 @@ from tests.test_utils import (
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 @pytest.mark.parametrize(
     "message_type",
     ["sms", "email", pytest.param("letter", marks=pytest.mark.template_preview)],
@@ -101,97 +100,87 @@ def test_send_csv(driver, login_seeded_user, client_live_key, client_test_key, m
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_edit_and_delete_email_template(driver, login_seeded_user, client_live_key):
-    test_name = "edit/delete email template test"
+    template_name = f"edit/delete email template test {uuid.uuid4()}"
     go_to_templates_page(driver)
-    existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(existing_templates) == 0:
-        existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
-    create_email_template(driver, name=test_name, content=None)
+    create_email_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
-    assert test_name in current_templates
+    assert template_name in current_templates
 
-    delete_template(driver, test_name)
+    delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
-    assert current_templates == existing_templates
+
+    assert template_name not in current_templates
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_edit_and_delete_sms_template(driver, login_seeded_user, client_live_key):
-    test_name = "edit/delete sms template test"
+    template_name = f"edit/delete sms template test {uuid.uuid4()}"
     go_to_templates_page(driver)
-    existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(existing_templates) == 0:
-        existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
-    create_sms_template(driver, name=test_name, content=None)
+    create_sms_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
-    assert test_name in current_templates
+    assert template_name in current_templates
 
-    delete_template(driver, test_name)
+    delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
-    assert current_templates == existing_templates
+
+    assert template_name not in current_templates
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_edit_and_delete_letter_template(driver, login_seeded_user, client_live_key):
-    test_name = "edit/delete letter template test"
+    template_name = f"edit/delete letter template test {uuid.uuid4()}"
     go_to_templates_page(driver)
-    existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(existing_templates) == 0:
-        existing_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
-    create_letter_template(driver, name=test_name, content=None)
+    create_letter_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
-    assert test_name in current_templates
+    assert template_name in current_templates
 
-    delete_template(driver, test_name)
+    delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
     if len(current_templates) == 0:
         current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
-    assert current_templates == existing_templates
+
+    assert template_name not in current_templates
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_add_and_delete_letter_attachment(driver, login_seeded_user, client_live_key):
-    test_name = "edit/delete letter attachment test"
+    template_name = f"edit/delete letter attachment test {uuid.uuid4()}"
     go_to_templates_page(driver)
-    create_letter_template(driver, name=test_name, content=None)
+    create_letter_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
-    add_letter_attachment_for_template(driver, name=test_name)
+    add_letter_attachment_for_template(driver, name=template_name)
     assert driver.find_element(By.CLASS_NAME, "edit-template-link-attachment").text == "Manage attachment"
     manage_letter_attachment(driver)
     assert driver.find_element(By.TAG_NAME, "h1").text == "blank_page.pdf"
     delete_letter_attachment(driver)
     go_to_templates_page(driver)
-    delete_template(driver, test_name)
+    delete_template(driver, template_name)
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
-def test_send_email_with_placeholders_to_one_recipient(driver, client_live_key, login_seeded_user):
+def test_send_email_with_placeholders_to_one_recipient(request, driver, client_live_key, login_seeded_user):
+    test_name = request.node.name
     go_to_templates_page(driver)
-    template_name = "email with placeholders" + str(uuid.uuid4())
+    template_name = f"email with placeholders {uuid.uuid4()}"
     content = "Hi ((name)), Is ((email address)) your email address? We want to send you some ((things))"
     template_id = create_email_template(driver, name=template_name, content=content)
 
@@ -213,14 +202,14 @@ def test_send_email_with_placeholders_to_one_recipient(driver, client_live_key, 
     dashboard_page.click_continue()
     notification_id = dashboard_page.get_notification_id()
     one_off_email = client_live_key.get_notification_by_id(notification_id)
-    assert one_off_email.get("created_by_name") == "Preview admin tests user"
+    assert one_off_email.get("created_by_name") == f"Preview admin tests user - {test_name}"
 
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
     dashboard_stats_after = get_dashboard_stats(dashboard_page, "email", template_id)
     assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after)
 
     placeholders_test = send_notification_to_one_recipient(
-        driver, template_name, "email", test=True, placeholders_number=2
+        driver, template_name, "email", test=True, placeholders_number=2, test_name=test_name
     )
     assert list(placeholders_test[0].keys()) == ["name"]
     assert list(placeholders_test[1].keys()) == ["things"]
@@ -229,10 +218,9 @@ def test_send_email_with_placeholders_to_one_recipient(driver, client_live_key, 
 
 
 @recordtime
-@pytest.mark.xdist_group(name="seeded-user")
 def test_send_sms_with_placeholders_to_one_recipient(driver, client_live_key, login_seeded_user):
     go_to_templates_page(driver)
-    template_name = "sms with placeholders" + str(uuid.uuid4())
+    template_name = f"sms with placeholders {uuid.uuid4()}"
     content = "Hi ((name)), Is ((phone number)) your mobile number? We want to send you some ((things))"
     template_id = create_sms_template(driver, name=template_name, content=content)
 
@@ -241,12 +229,7 @@ def test_send_sms_with_placeholders_to_one_recipient(driver, client_live_key, lo
     dashboard_stats_before = get_dashboard_stats(dashboard_page, "sms", template_id)
 
     placeholders = send_notification_to_one_recipient(
-        driver,
-        template_name,
-        "sms",
-        test=False,
-        recipient_data=os.environ["TEST_NUMBER"],
-        placeholders_number=2,
+        driver, template_name, "sms", test=False, recipient_data=os.environ["TEST_NUMBER"], placeholders_number=2
     )
     assert list(placeholders[0].keys()) == ["name"]
     assert list(placeholders[1].keys()) == ["things"]
@@ -272,36 +255,9 @@ def test_send_sms_with_placeholders_to_one_recipient(driver, client_live_key, lo
 
 
 @pytest.mark.template_preview
-@pytest.mark.xdist_group(name="seeded-user")
 def test_view_precompiled_letter_message_log_delivered(driver, login_seeded_user, client_test_key):
 
-    reference = "functional_tests_precompiled_" + str(uuid.uuid1()) + "_delivered"
-
-    send_precompiled_letter_via_api(
-        reference,
-        client_test_key,
-        BytesIO(base64.b64decode(correct_letter)),
-    )
-
-    api_integration_page = ApiIntegrationPage(driver)
-
-    retry_call(
-        _check_status_of_notification,
-        fargs=[api_integration_page, config["service"]["id"], reference, "received"],
-        tries=config["notification_retry_times"],
-        delay=config["notification_retry_interval"],
-    )
-
-    ref_link = config["service"]["id"] + "/notification/" + api_integration_page.get_notification_id()
-    link = api_integration_page.get_view_letter_link()
-    assert ref_link in link
-
-
-@pytest.mark.template_preview
-@pytest.mark.xdist_group(name="seeded-user")
-def test_view_precompiled_letter_preview_delivered(driver, login_seeded_user, client_test_key):
-
-    reference = "functional_tests_precompiled_letter_preview_" + str(uuid.uuid1()) + "_delivered"
+    reference = f"functional_tests_precompiled_{uuid.uuid4()}_delivered"
 
     notification_id = send_precompiled_letter_via_api(
         reference,
@@ -318,7 +274,32 @@ def test_view_precompiled_letter_preview_delivered(driver, login_seeded_user, cl
         delay=config["notification_retry_interval"],
     )
 
-    api_integration_page.go_to_preview_letter()
+    ref_link = config["notify_admin_url"] + "/services/" + config["service"]["id"] + "/notification/" + notification_id
+    link = api_integration_page.get_view_letter_link(reference)
+    assert link == ref_link
+
+
+@pytest.mark.template_preview
+def test_view_precompiled_letter_preview_delivered(driver, login_seeded_user, client_test_key):
+
+    reference = f"functional_tests_precompiled_letter_preview_{uuid.uuid4()}_delivered"
+
+    notification_id = send_precompiled_letter_via_api(
+        reference,
+        client_test_key,
+        BytesIO(base64.b64decode(correct_letter)),
+    )
+
+    api_integration_page = ApiIntegrationPage(driver)
+
+    retry_call(
+        _check_status_of_notification,
+        fargs=[api_integration_page, config["service"]["id"], reference, "received"],
+        tries=config["notification_retry_times"],
+        delay=config["notification_retry_interval"],
+    )
+
+    api_integration_page.go_to_preview_letter(reference)
 
     letter_preview_page = PreviewLetterPage(driver)
     assert letter_preview_page.is_text_present_on_page("Provided as PDF")
@@ -326,7 +307,14 @@ def test_view_precompiled_letter_preview_delivered(driver, login_seeded_user, cl
     # Check the pdf link looks valid
     pdf_download_link = letter_preview_page.get_download_pdf_link()
 
-    link = config["service"]["id"] + "/notification/" + notification_id + ".pdf"
+    link = (
+        config["notify_admin_url"]
+        + "/services/"
+        + config["service"]["id"]
+        + "/notification/"
+        + notification_id
+        + ".pdf"
+    )
 
     assert link in pdf_download_link
 
@@ -345,7 +333,6 @@ def test_view_precompiled_letter_preview_delivered(driver, login_seeded_user, cl
 
 
 @pytest.mark.antivirus
-@pytest.mark.xdist_group(name="seeded-user")
 def test_view_precompiled_letter_message_log_virus_scan_failed(driver, login_seeded_user, client_test_key):
 
     reference = "functional_tests_precompiled_" + str(uuid.uuid1()) + "_virus_scan_failed"
@@ -370,16 +357,13 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(driver, login_see
         delay=config["notification_retry_interval"],
     )
 
-    ref_link = config["service"]["id"] + "/notification/" + api_integration_page.get_notification_id()
-    link = api_integration_page.get_view_letter_link()
-    assert ref_link not in link
+    assert api_integration_page.get_view_letter_link(reference) is None
 
 
-@pytest.mark.xdist_group(name="seeded-user")
 def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user):
     # create new template
-    template_name = "template-for-folder-test {}".format(uuid.uuid4())
-    folder_name = "test-folder {}".format(uuid.uuid4())
+    template_name = f"template-for-folder-test {uuid.uuid4()}"
+    folder_name = f"test-folder {uuid.uuid4()}"
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(config["service"]["id"])
@@ -438,8 +422,7 @@ def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user
     assert template_name not in [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
 
-@pytest.mark.xdist_group(name="seeded-user")
-def test_template_folder_permissions(driver, login_seeded_user):
+def test_template_folder_permissions(driver, request, login_seeded_user):
     family_id = uuid.uuid4()
     folder_names = [
         "test-parent-folder {}".format(family_id),
@@ -497,7 +480,7 @@ def test_template_folder_permissions(driver, login_seeded_user):
     show_templates_page.click_template_by_link_text(folder_names[2] + "_template")
     dashboard_page.sign_out()
     # delete everything
-    sign_in(driver, account_type="seeded")
+    sign_in(driver, account_type="seeded", test_name=request.node.name)
     dashboard_page.go_to_dashboard_for_service(config["service"]["id"])
     dashboard_page.click_templates()
     show_templates_page = ShowTemplatesPage(driver)
@@ -521,9 +504,8 @@ def test_template_folder_permissions(driver, login_seeded_user):
 def _check_status_of_notification(page, functional_tests_service_id, reference_to_check, status_to_check):
     page.go_to_api_integration_for_service(service_id=functional_tests_service_id)
     page.expand_all_messages()
-    client_reference = page.get_client_reference()
-    assert reference_to_check == client_reference
-    assert status_to_check == page.get_status_from_message()
+    notification_offset = page.find_notification_offset_for_client_reference(reference_to_check)
+    assert status_to_check == page.get_notification_status_for_log_offset(notification_offset)
 
 
 @retry_on_stale_element_exception
@@ -536,7 +518,7 @@ def get_dashboard_stats(dashboard_page, message_type, template_id):
 
 def assert_dashboard_stats(dashboard_stats_before, dashboard_stats_after):
     for k in dashboard_stats_before.keys():
-        assert dashboard_stats_after[k] == dashboard_stats_before[k] + 1
+        assert dashboard_stats_after[k] > dashboard_stats_before[k]
 
 
 def _get_template_count(dashboard_page, template_id):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -117,11 +117,10 @@ class InviteUserPageLocators(object):
 
 
 class ApiIntegrationPageLocators(object):
-    MESSAGE_LOG = (By.CSS_SELECTOR, "div.api-notifications > details:nth-child(1)")
+    MESSAGE_LOG = (By.CSS_SELECTOR, "div.api-notifications details")
     HEADING_BUTTON = (By.CSS_SELECTOR, ".govuk-details__summary")
-    CLIENT_REFERENCE = (By.CSS_SELECTOR, ".api-notifications-item__data-value")
-    MESSAGE_LIST = (By.CSS_SELECTOR, ".api-notifications-item__data-value")
-    STATUS = (By.CSS_SELECTOR, ".api-notifications-item__data-value:last-of-type")
+    CLIENT_REFERENCE = (By.CSS_SELECTOR, ".govuk-details__text .api-notifications-item__data-value:nth-of-type(2)")
+    STATUS = (By.CSS_SELECTOR, ".govuk-details__text .api-notifications-item__data-value:last-of-type")
     VIEW_LETTER_LINK = (By.LINK_TEXT, "View letter")
 
 


### PR DESCRIPTION
(Requires https://github.com/alphagov/notifications-credentials/pull/377 and https://github.com/alphagov/notifications-api/pull/3851 to be merged first for CI tests to pass)

---

The slowest group of tests in our functional test suite at the moment
is the xdist group 'seeded-user'. These tests all run using a
pre-defined user account in a specific organisation and service, with
specific permissions. The tests don't necessarily step on each other's
toes that much, but our app enforces only one user session can be active
at a time. If two of the seeded-user tests run at the same time, one of
the sessions will be killed by the other.

To deal with this, let's instead use a new private API endpoint to
create a 'seeded' user for each test that needs one. This will let all
of those tests run in parallel and give us a much faster runtime for the
full suite of tests.

At startup, we analyse all of the tests that have the
'login_seeded_user' fixture, and post a request to the API endpoint to
make sure that users exist for all of those tests. We then rewrite the
`get_email_and_password` helper to return the unique per-test email
address. We only execute this flow on one of the workers using a
temporary file to guarantee only a single execution.

There are a few tests that read/write templates and other central
objects at the same time. Where tests do that, we make sure to either
create each template with a unique name, or use an arbitrary locking
method to ensure only one test can be inside a given block of code at a
time. The latter is most relevant for letter template tests, as letter
templates are all created with the name 'Untitled letter template' and
need to be made unique in multiple steps.

For a locking mechanism we can use a simple file-based lock, as the test
run is not executed across multiple machines.

---

I'm hopeful we can extend this de-grouping effort to other xdist groups at some point in the future, with the ideal situation (probably) being all tests being able to run independently (and ideally removing the concept of "pre-existing"/seeded DB fixtures altogether)

# Timing

I've excluded the broadcast tests as these should be disappearing from our suite soon. And at the time of writing these were running slow ([probably related to this](https://github.com/alphagov/notifications-manuals/wiki/Useful-queries#delete-old-broadcast-messages))

## Before - 6m46
Notice that even though we spin up 10 workers, we can only use 5 because we only have 5 xdist loadgroups.
<img width="1305" alt="image" src="https://github.com/alphagov/notifications-functional-tests/assets/2920760/6de8be63-5bff-4cf9-a470-a7151bb8f88a">


## After - 2m13s
Notice that we can now actually use all of our workers, and so do more work at once.
<img width="1306" alt="image" src="https://github.com/alphagov/notifications-functional-tests/assets/2920760/3ff3191e-5cb4-443a-b9e5-f78d0cf58b67">


<details><summary>Taking it one step further...</summary>
<p>
We have the possibility of taking this even further by increasing the number of workers beyond that provided by `-nauto` (8 on concourse). Because a fair chunk of the work is waiting for IO across the network, we can probably have more workers than CPUs.

By bumping workers up to 16 locally (vs preview) I managed to get runtime down to 1m44. Would need to validate whether this is worth doing on concourse though.

<img width="1308" alt="image" src="https://github.com/alphagov/notifications-functional-tests/assets/2920760/7290bd3c-1931-4dc7-b2e6-869521b19fa7">
</p>
</details> 
