### PR TITLE
Allow setting dev domains from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Note, there is an order dependency in the main tests. The registration test must
 
 **Note: this is currently only supported for `functional/` and `document_download/` tests.** See the next section if you want to run the `provider_delivery/` tests locally.
 
+If you are running Notify locally using docker-compose via [notifications-local](https://www.github.com/alphagov/notifications-local), then you need to set the following environment variables:
+
+```
+FUNCTIONAL_TESTS_LOCAL_API_HOST=http://notify-api.localhost:6011
+FUNCTIONAL_TESTS_LOCAL_ADMIN_HOST=http://notify.localhost:6012
+FUNCTIONAL_TESTS_LOCAL_ALERTS_HOST=http://notify.localhost:6017/alerts
+```
+
 Populate the local database with fixture data:
 
 ```shell

--- a/config.py
+++ b/config.py
@@ -41,9 +41,9 @@ config = {
 
 urls = {
     "dev": {
-        "api": "http://localhost:6011",
-        "admin": "http://localhost:6012",
-        "govuk_alerts": "http://localhost:6017/alerts",
+        "api": os.environ.get("FUNCTIONAL_TESTS_LOCAL_API_HOST", "http://localhost:6011"),
+        "admin": os.environ.get("FUNCTIONAL_TESTS_LOCAL_ADMIN_HOST", "http://localhost:6012"),
+        "govuk_alerts": os.environ.get("FUNCTIONAL_TESTS_LOCAL_ALERTS_HOST", "http://localhost:6017/alerts"),
     },
     "preview": {
         "api": "https://api.notify.works",


### PR DESCRIPTION
This is useful if running the apps via notifications-local/docker-compose instead of natively.

As/when we are confident about docker-compose being the default we could change the default domains to be the notify.localhost ones.