### PR TITLE
Disable broadcast tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ clean: ## Remove temporary files
 test: clean ## Run functional tests against local environment
 	ruff check .
 	black --check .
-	pytest -v tests/functional/preview_and_dev -n auto --dist loadgroup
-	pytest -v tests/document_download/preview_and_dev
+	pytest -v tests/functional/preview_and_dev -n auto --dist loadgroup ${FUNCTIONAL_TESTS_EXTRA_PYTEST_ARGS}
+	pytest -v tests/document_download/preview_and_dev ${FUNCTIONAL_TESTS_EXTRA_PYTEST_ARGS}
 
 .PHONY: generate-staging-db-fixtures
 generate-staging-db-fixtures: ## Generates DB fixtures for the staging database

--- a/environment_local.sh
+++ b/environment_local.sh
@@ -36,3 +36,4 @@ export BROADCAST_USER_2_NUMBER=07700900003
 
 export BROADCAST_SERVICE_ID='8e1d56fa-12a8-4d00-bed2-db47180bed0a'
 export BROADCAST_SERVICE_LIVE_API_KEY='func_tests_broadcast_service_live_key-8e1d56fa-12a8-4d00-bed2-db47180bed0a-c3e6b68f-bd43-4e33-8fba-67a8c1bad4a3'
+export FUNCTIONAL_TESTS_EXTRA_PYTEST_ARGS='-m "not broadcast"'


### PR DESCRIPTION
Most of us don't run gov.uk alerts locally, and we will soon be stopping to support the EA code. Let's exclude broadcast functional tests from running locally by default.