### PR TITLE
handle if we're already signed in when trying to sign in

### DIFF
--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -27,7 +27,7 @@ def test_reset_forgotten_password(driver, request):
     email, password = get_email_and_password(account_type="seeded", test_name=request.node.name)
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
-    assert sign_in_page.is_current()
+    sign_in_page.wait_until_current()
     sign_in_page.click_forgot_password_link()
 
     forgot_password_page = ForgotPasswordPage(driver)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -276,7 +276,7 @@ class RegistrationPage(BasePage):
     mobile_input = MobileInputElement()
     password_input = PasswordInputElement()
 
-    def is_current(self):
+    def wait_until_current(self):
         return self.wait_until_url_is(self.base_url + "/register")
 
     def register(self):
@@ -292,7 +292,7 @@ class AddServicePage(BasePage):
     org_type_input = AddServicePageLocators.ORG_TYPE_INPUT
     add_service_button = AddServicePageLocators.ADD_SERVICE_BUTTON
 
-    def is_current(self):
+    def wait_until_current(self):
         return self.wait_until_url_is(self.base_url + "/add-service?first=first")
 
     def add_service(self, name):
@@ -338,7 +338,7 @@ class SignInPage(BasePage):
     def get(self):
         self.driver.get(self.base_url + "/sign-in")
 
-    def is_current(self):
+    def wait_until_current(self):
         return self.wait_until_url_is(self.base_url + "/sign-in")
 
     def fill_login_form(self, email, password):

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -29,7 +29,7 @@ def _sign_in(driver, account_type, test_name=None):
     sign_in_page.get()
 
     try:
-        sign_in_page.is_current()
+        sign_in_page.wait_until_current()
     except TimeoutException:
         # if we didn't get to the sign_in_page, it's probably because we're already logged in.
         # try logging out before proceeding

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from filelock import FileLock
+from selenium.common.exceptions import TimeoutException
 
 from config import config, generate_unique_email
 from tests.pages import SignInPage
@@ -26,7 +27,15 @@ def sign_in_email_auth(driver):
 def _sign_in(driver, account_type, test_name=None):
     sign_in_page = SignInPage(driver)
     sign_in_page.get()
-    assert sign_in_page.is_current()
+
+    try:
+        sign_in_page.is_current()
+    except TimeoutException:
+        # if we didn't get to the sign_in_page, it's probably because we're already logged in.
+        # try logging out before proceeding
+        sign_in_page.sign_out()
+        sign_in_page.get()
+
     email, password = get_email_and_password(account_type=account_type, test_name=test_name)
     sign_in_page.login(email, password)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,7 +144,7 @@ def do_user_registration(driver):
     main_page.click_set_up_account()
 
     registration_page = RegistrationPage(driver)
-    assert registration_page.is_current()
+    registration_page.wait_until_current()
 
     registration_page.register()
 
@@ -157,7 +157,7 @@ def do_user_registration(driver):
     do_verify(driver, config["user"]["mobile"])
 
     add_service_page = AddServicePage(driver)
-    assert add_service_page.is_current()
+    add_service_page.wait_until_current()
     add_service_page.add_service(config["service_name"])
 
     dashboard_page = DashboardPage(driver)
@@ -168,7 +168,6 @@ def do_user_registration(driver):
 
 
 def do_user_can_invite_someone_to_notify(driver, basic_view):
-
     dashboard_page = DashboardPage(driver)
     dashboard_page.click_team_members_link()
 
@@ -298,7 +297,6 @@ def delete_template(driver, template_name, service="service"):
 
 
 def add_letter_attachment_for_template(driver, name, service="service"):
-
     show_templates_page = ShowTemplatesPage(driver)
     try:
         show_templates_page.click_template_by_link_text(name)


### PR DESCRIPTION
many tests sign in at the beginning. if they then fail, they'll be retried on concourse but the user will stil be signed in. the first thing the second run of the test does is try and sign in again, which will throw an exception when it tries to go to the sign_in page cos it'll redirect to /accounts-and-services which the functional tests don't expect.

so instead, catch this error, and try to sign out before continuing