### PR TITLE
Force all requests to PaaS by default (not ECS)

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -13,6 +13,8 @@ def ecs_override_generate_headers(self, api_token):
     headers = self.original_generate_headers(api_token)
     if os.getenv("NOTIFY_ECS_ORIGIN"):
         headers["x-notify-ecs-origin"] = "true"
+    else:
+        headers["x-notify-paas-origin"] = "true"
     return headers
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,12 @@ def _driver(request, download_directory):
     driver.set_window_size(1280, 720)
 
     def interceptor(request):
-        request.headers["x-notify-ecs-origin"] = "true"
+        if os.getenv("NOTIFY_ECS_ORIGIN"):
+            request.headers["x-notify-ecs-origin"] = "true"
+        else:
+            request.headers["x-notify-paas-origin"] = "true"
 
-    if os.getenv("NOTIFY_ECS_ORIGIN"):
-        driver.request_interceptor = interceptor
+    driver.request_interceptor = interceptor
 
     driver.delete_all_cookies()
 

--- a/tests/document_download/preview_and_dev/test_document_download.py
+++ b/tests/document_download/preview_and_dev/test_document_download.py
@@ -65,9 +65,10 @@ def test_document_upload_and_download(driver, client_live_key):
     download_page = DocumentDownloadPage(driver)
     document_url = download_page.get_download_link()
 
-    headers = {}
     if os.getenv("NOTIFY_ECS_ORIGIN"):
         headers = {"x-notify-ecs-origin": "true"}
+    else:
+        headers = {"x-notify-paas-origin": "true"}
 
     downloaded_document = requests.get(document_url, headers=headers)
 

--- a/tests/functional/preview_and_dev/test_inbound_sms.py
+++ b/tests/functional/preview_and_dev/test_inbound_sms.py
@@ -34,9 +34,10 @@ def inbound_sms():
         "DateRecieved": quote_plus(datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")),
     }
 
-    headers = {}
     if os.getenv("NOTIFY_ECS_ORIGIN"):
         headers = {"x-notify-ecs-origin": "true"}
+    else:
+        headers = {"x-notify-paas-origin": "true"}
 
     response = requests.post(
         config["notify_api_url"] + "/notifications/sms/receive/mmg",


### PR DESCRIPTION
https://trello.com/c/hqk5BXGG/590-force-paas-functional-tests-to-send-requests-to-the-paas

This mimics the equivalent for ECS
(https://github.com/alphagov/notifications-functional-tests/pull/459/files) apart from we make it the default so that we don't need to go and update all our PaaS functional test pipelines to include a new environment variable.

Note, on ECS once a request enters ECS, all inter app requests also stay in ECS. This is NOT true for the PaaS though. For example if we send a request to the admin app in PaaS and the admin app needs to query the API to get some data, then the request to the API goes back out through cloudfront. The consequence of this is that this change doesn't enforce all requests will stay in the PaaS because inter app requests may go back out to cloudfront and be at the mercy of cloudfront percentage based traffic routing.

We have a few options:

1. Tolerate the above behaviour, knowing that at least the initial request will go to the PaaS. Also not all journeys will be affected because they don't make interapp requests, for example sending an email via our API doesn't make an interapp requests.
2. Change the behaviour in the PaaS so that all inter app requests are forced to go to the PaaS. We can do this by changing their URLs to be the PaaS provided ones (like app-name-production.cloudapps.digital).
3. Write some python code in our apps so that inter app requests will inspect the HTTP headers on the request and then propogate that header onwards for any inter app requests it makes.