### PR TITLE
Fixes race condition when pdf generation is slow

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ config = {
     # static
     "notification_retry_times": 15,
     "notification_retry_interval": 5,
+    "pdf_generation_retry_times": 5,
+    "pdf_generation_retry_interval": 1,
     "letter_retry_times": 48,
     "provider_retry_times": 12,
     "provider_retry_interval": 22,

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -301,7 +301,14 @@ def test_add_letter_attachment_then_send_letter_then_delete_attachment(driver, l
         delay=config["notification_retry_interval"],
     )
 
-    letter_pdf = get_pdf_for_letter_via_api(client_live_key, notification_id)
+    # wait until the PDF for the letter is generated
+    letter_pdf = retry_call(
+        get_pdf_for_letter_via_api,
+        fargs=[client_live_key, notification_id],
+        tries=config["pdf_generation_retry_times"],
+        delay=config["pdf_generation_retry_interval"],
+    )
+
     pdf_reader = PdfReader(letter_pdf)
     assert len(pdf_reader.pages) == 2
     attachment_page = pdf_reader.pages[1]


### PR DESCRIPTION
What
----

Fixes a race condition in the functional tests when the pdf generation is slow.

Example failure caused by this can be seen in

notify-infra/run-terraform-preview build #718

Web call time according to ecs-logs:
```
February 26th 2024, 15:29:16.702	/notify/ecs/api-web GET http://api.notify.works/v2/notifications/b9b22eb4-2153-48c8-bbe7-7e151fe40710/pdf 10.201.23.244 400 0.073
```

So we are returning a 400 as the pdf doesn't exist yet.

template-preview-worker log:

```
February 26th 2024, 15:29:15.547	/notify/ecs/template-preview-worker INFO Creating a pdf for notification with id b9b22eb4-2153-48c8-bbe7-7e151fe40710
February 26th 2024, 15:29:16.779	/notify/ecs/template-preview-worker INFO Uploaded letters PDF 2024-02-26/NOTIFY.ZUEHZ10W3PGVQRGR.D.2.C.20240226152915.PDF to preview-letters-pdf for notification id b9b22eb4-2153-48c8-bbe7-7e151fe40710
February 26th 2024, 15:29:16.881	/notify/ecs/template-preview-worker INFO Celery task create-pdf-for-templated-letter (queue: sanitise-letter-tasks) took 1.3348
```

Essentially the pdf generation was too slow by 179 millisecond.


