### PR TITLE
Change the way selenium selects the alternative sender

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,25 @@ FROM python:3.11 as python-chromedriver-copy
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
 RUN apt-get -y update
-RUN apt-get install -y google-chrome-stable
+####
+# Fix version of google-chrome-stable to avoid breaking changes.
+# Breaking changes were in version 127.0.6533.88
+# RUN apt-get install -y google-chrome-stable
+RUN cd /tmp && \
+    wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.126-1_amd64.deb && \
+    apt install -y ./google-chrome-stable_126.0.6478.126-1_amd64.deb && \
+    rm google-chrome-stable_126.0.6478.126-1_amd64.deb
+####
 
 # install chromedriver
 RUN apt-get install -yqq unzip jq
-RUN curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -rc '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64").url' > /tmp/chromedriver_url
-RUN wget -O /tmp/chromedriver.zip `cat /tmp/chromedriver_url`
+####
+# Fix version of chromedriver to avoid breaking changes. See above.
+# RUN curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -rc '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64").url' > /tmp/chromedriver_url
+# RUN wget -O /tmp/chromedriver.zip `cat /tmp/chromedriver_url`
+RUN wget -O /tmp/chromedriver.zip https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/linux64/chromedriver-linux64.zip
+#
+####
 RUN unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
 # set display port to avoid crash

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -149,6 +149,10 @@ class SingleRecipientLocators(object):
     PLACEHOLDER_VALUE_INPUT = (By.NAME, "placeholder_value")
     PREVIEW_TABLE = (By.CLASS_NAME, "email-message-meta")
     ALTERNATIVE_SENDER_RADIO = (By.CSS_SELECTOR, "input[type='radio'][id='sender-1']")
+    ALTERNATIVE_SENDER_SMS_RADIO = (
+        By.XPATH,
+        "//label[normalize-space(text())='func tests']/preceding-sibling::input[@type='radio']",
+    )
     ADDRESS_INPUT = (By.ID, "address")
     CONTINUE_BUTTON = (
         By.XPATH,

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -966,6 +966,10 @@ class SendOneRecipient(BasePage):
         radio = self.wait_for_design_system_checkbox_or_radio(SingleRecipientLocators.ALTERNATIVE_SENDER_RADIO)
         radio.click()
 
+    def choose_alternative_sms_sender(self):
+        radio = self.wait_for_design_system_checkbox_or_radio(SingleRecipientLocators.ALTERNATIVE_SENDER_SMS_RADIO)
+        radio.click()
+
     def send_to_myself(self, message_type):
         if message_type == "email":
             element = self.wait_for_element(SingleRecipientLocators.USE_MY_EMAIL)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -387,7 +387,10 @@ def send_notification_to_one_recipient(
     view_template_page.click_send()
 
     send_to_one_recipient_page = SendOneRecipient(driver)
-    send_to_one_recipient_page.choose_alternative_sender()
+    if message_type == "sms":
+        send_to_one_recipient_page.choose_alternative_sms_sender()
+    else:
+        send_to_one_recipient_page.choose_alternative_sender()
     send_to_one_recipient_page.click_continue()
     if test is True:
         send_to_one_recipient_page.send_to_myself(message_type)


### PR DESCRIPTION
[Trello](https://trello.com/c/a4q9X0Tf/850-carry-out-integration-testing)

What
----

- Lock version of chrome to 126.0.6478.126-1. This is because tests don't run with 127.0.6533.88. We will need to come back to investigate this later.
- Instead of selecting it by position in the list it selects it by value.

Why
----

As part of a service creation we get a sender and then we add the two more we want. Essentially we end up with 3 senders.

The ordering is purely done by the default first. The second item is whatever the database wants.