### PR TITLE
Add makefile targets to run different test types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,41 @@ clean: ## Remove temporary files
 	rm -rf screenshots/*
 	rm -rf logs/*
 
+.PHONY: $(filter-out dev%,$(MAKECMDGOALS))
+dev%:
+	$(eval export ENVIRONMENT=$@)
+	@true
+
+.PHONY: preview
+preview:
+	$(eval export ENVIRONMENT=preview)
+	@true
+
+.PHONY: staging
+staging:
+	$(eval export ENVIRONMENT=staging)
+	@true
+
+.PHONY: prod
+prod:
+	$(eval export ENVIRONMENT=prod)
+	@true
+
+env-environment-check:
+	@test -n "${ENVIRONMENT}" || (echo "ENVIRONMENT variable is not set"; exit 1)
+
+.PHONY: env-functional-tests
+env-functional-tests: env-environment-check
+	@./scripts/env-test.sh "${ENVIRONMENT}" tests/functional/preview_and_dev tests/document_download/preview_and_dev
+
+.PHONY: env-smoke-tests
+env-smoke-tests: env-environment-check
+	@./scripts/env-test.sh "${ENVIRONMENT}" tests/functional/staging_and_prod tests/document_download/staging_and_prod
+
+.PHONY: env-provider-tests
+env-provider-tests: env-environment-check
+	@./scripts/env-test.sh "${ENVIRONMENT}" tests/provider_delivery/test_provider_delivery_email.py tests/provider_delivery/test_provider_delivery_sms.py
+
 .PHONY: test
 test: clean ## Run functional tests against local environment
 	ruff check .

--- a/config.py
+++ b/config.py
@@ -106,6 +106,7 @@ def setup_preview_dev_config():
 
     config.update(
         {
+            "name": "{} Functional Tests".format(config["env"]),
             "service_name": "Functional Test_{}".format(uuid_for_test_run),
             "user": {
                 "name": "{}_Functional Test_{}".format(config["env"], uuid_for_test_run),

--- a/scripts/env-test.sh
+++ b/scripts/env-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eo pipefail
+
+ENVIRONMENT=$1
+
+AWS_REGION="eu-west-1"
+export AWS_REGION
+AWS_DEFAULT_REGION=$AWS_REGION
+export AWS_DEFAULT_REGION
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+if [ -z "$$(ACCOUNT_ID)" ]; then echo "ACCOUNT_ID is empty"; exit 1; fi
+
+PARAMS=$(aws ssm get-parameter --with-decryption --name arn:aws:ssm:eu-west-1:${ACCOUNT_ID}:parameter/notify/${ENVIRONMENT}/functional-tests/generated/environment | jq -r .Parameter.Value)
+source /dev/stdin <<< "${PARAMS}"
+
+export API_FIXTURE_APPLIED="true"
+
+# loop through each of our args after the environment
+for arg in "${@:2}";
+do
+    pytest -v $arg -n 4 --dist loadgroup ${FUNCTIONAL_TESTS_EXTRA_PYTEST_ARGS}
+done

--- a/tests/document_download/staging_and_prod/conftest.py
+++ b/tests/document_download/staging_and_prod/conftest.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from config import setup_staging_prod_config
+from config import setup_preview_dev_config, setup_staging_prod_config
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -8,4 +10,7 @@ def staging_prod_config():
     """
     Setup
     """
-    setup_staging_prod_config()
+    if os.environ.get("API_FIXTURE_APPLIED") == "true":
+        setup_preview_dev_config()
+    else:
+        setup_staging_prod_config()

--- a/tests/functional/staging_and_prod/conftest.py
+++ b/tests/functional/staging_and_prod/conftest.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from config import setup_staging_prod_config
+from config import setup_preview_dev_config, setup_staging_prod_config
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -8,4 +10,7 @@ def staging_prod_config():
     """
     Setup
     """
-    setup_staging_prod_config()
+    if os.environ.get("API_FIXTURE_APPLIED") == "true":
+        setup_preview_dev_config()
+    else:
+        setup_staging_prod_config()

--- a/tests/provider_delivery/conftest.py
+++ b/tests/provider_delivery/conftest.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from config import setup_staging_prod_config
+from config import setup_preview_dev_config, setup_staging_prod_config
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -8,4 +10,7 @@ def staging_prod_config():
     """
     Setup
     """
-    setup_staging_prod_config()
+    if os.environ.get("API_FIXTURE_APPLIED") == "true":
+        setup_preview_dev_config()
+    else:
+        setup_staging_prod_config()


### PR DESCRIPTION
[Trello](https://trello.com/c/frASlujj/849-get-smoke-tests-running)

What
----

Add makefile targets to allow you to run tests against an environment.

This adds the following make targets:

- env-functional-tests : run  functional tests (dev_and_preview)
- env-smoke-tests: run smoke tests (staging_and_production)
- env-provider-tests: run incoming provider tests (staging_and_production)

All these new make targets are designed to run against the new environments (i.e. currently dev-*).

AWS credentials will be required to pull the environment file from ssm.

If we want to run these against preview, staging and production we would need to apply the api-functional-tests-fixtures tasks. To be decided what we do once we want to cutover production.

Notes
----

I will set up further tickets on the functional tests. These will include the following:
- Rename dev_and_preview/staging_and_production to be a group test name. (e.g. integration tests, smoke tests and provider tests)
- Change the fact that we have two formats for environment variables that feed into the tests. E.g. we have a preview_and_dev set of environment variables and a staging_and_production set. We should just have one.
- Figure out what to do with test_provider_inbound_sms.py which currently does not run as we have no incoming numbers to dev environments
- Decide how these tests are going to work when we cutover production to use the new pipeline.
