### PR TITLE
Adding make for functional-test fixtures on local-dev point to notify-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ generate-staging-db-fixtures: ## Generates DB fixtures for the staging database
 	    --format=json \
 	    -o db_fixtures/staging.sql \
 	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/functional-tests/staging-functional-db-fixtures.gpg) 2>&1
+
+.PHONY: generate-local-dev-db-fixtures
+generate-local-dev-db-fixtures:
+	$(MAKE) -C ../notifications-local generate-local-dev-db-fixtures


### PR DESCRIPTION
First draft. It requires that two environment variables have been added to notifications-local/private/notify-api.env 
FUNCTIONAL_TEST_ENV_FILE
REQUEST_BIN_API_TOKEN