### PR TITLE
Add awscli to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install selenium
 
 FROM python-chromedriver-copy AS functional-tests-image
 
-RUN apt install -y poppler-utils libzbar0
+RUN apt install -y awscli poppler-utils libzbar0
 
 WORKDIR /var/project
 COPY . .


### PR DESCRIPTION
[Trello card](https://trello.com/c/Q8OS5ty9/848-add-fts-to-the-pipeline)

`scripts/env-test.sh` (called by the `env-*-tests` targets in the Makefile) depends on the AWS CLI to get the SSM parameter that contains the env vars that the functional tests need to run.

As Concourse runs the FTs inside the built image, let's make sure the built image contains the AWS CLI.