### PR TITLE
Use Debian-packaged chromium & chromium-driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,24 @@
-# The jorzoursky/python-chromedriver image does not have a published 3.11 tag yet, so copy the dockerfile across from
-# https://github.com/joyzoursky/docker-python-chromedriver/blob/master/py-debian/3.11-selenium/Dockerfile
-FROM python:3.11 as python-chromedriver-copy
+FROM python:3.11
 
-# install google chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-RUN apt-get -y update
-####
-# Fix version of google-chrome-stable to avoid breaking changes.
-# Breaking changes were in version 127.0.6533.88
-# RUN apt-get install -y google-chrome-stable
-RUN cd /tmp && \
-    wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.126-1_amd64.deb && \
-    apt install -y ./google-chrome-stable_126.0.6478.126-1_amd64.deb && \
-    rm google-chrome-stable_126.0.6478.126-1_amd64.deb
-####
+# Ensure we're using Chromium v126.x
+# (Remove this if/when the performance regression in v127+ is resolved)
+COPY ./debian.sources /etc/apt/sources.list.d/debian.sources
 
-# install chromedriver
-RUN apt-get install -yqq unzip jq
-####
-# Fix version of chromedriver to avoid breaking changes. See above.
-# RUN curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -rc '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64").url' > /tmp/chromedriver_url
-# RUN wget -O /tmp/chromedriver.zip `cat /tmp/chromedriver_url`
-RUN wget -O /tmp/chromedriver.zip https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.126/linux64/chromedriver-linux64.zip
-#
-####
-RUN unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
-
-# set display port to avoid crash
-ENV DISPLAY=:99
-
-# upgrade pip
-RUN pip install --upgrade pip
-
-# install selenium
-RUN pip install selenium
-
-# --------------- Our own dockerfile instructions follow:
-
-FROM python-chromedriver-copy AS functional-tests-image
-
-RUN apt install -y awscli poppler-utils libzbar0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        awscli \
+        chromium \
+        chromium-driver \
+        jq \
+        libzbar0 \
+        poppler-utils \
+        && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/project
+
 COPY . .
+
 RUN make bootstrap
-ENTRYPOINT bash
+
+ENTRYPOINT ["bash"]

--- a/debian.sources
+++ b/debian.sources
@@ -1,0 +1,13 @@
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian/20240718T055647Z
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: false
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/20240718T055647Z
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: false


### PR DESCRIPTION
[Trello card](https://trello.com/c/9AWH7VCa/875-use-chromium-and-chromium-driver-from-debian-apt-repo-in-builds-of-the-functional-test-docker-image)

We currently install the latest version of Chrome from Google’s apt repo, and the latest version of Chromedriver from chrome-for-testing. This is brittle, because it’s not guaranteed that we’ll end up with matching versions of Chrome and Chromedriver.

We should use Debian’s own chromium and chromium-driver packages instead.

Selenium seems to be able to find Chromium automatically (even though it lives in a different path than Chrome), so we don't need to make any changes to our test config.

We will continue pinning Chromium v126 for now, because v127 and later are incompatible with our functional tests. This will need to be followed up with some more work to investigate why v127+ isn't working (so that we can unpin v126), and/or switch to a different browser such as Firefox.

Tested [with the existing CI for this repo](https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/build-functional-tests-pr/builds/286) and [on dev-c](https://concourse.notify.tools/teams/dev-c/pipelines/deploy-notify/jobs/test/builds/18).