### PR TITLE
Fix test that involve Templates Folder page

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -117,7 +117,7 @@ class InviteUserPageLocators(object):
     )
     CHOOSE_FOLDERS_BUTTON = (
         By.CSS_SELECTOR,
-        "button[aria-controls=folder_permissions]",
+        "button.notify-button--with-chevron",
     )
     SEND_INVITATION_BUTTON = (
         By.CSS_SELECTOR,

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -445,7 +445,7 @@ class DashboardPage(BasePage):
         return int(element.text)
 
 
-class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
+class ShowTemplatesPage(BasePage):
     add_new_template_link = (By.CSS_SELECTOR, "button[value='add-new-template']")
     add_new_folder_link = (By.CSS_SELECTOR, "button[value='add-new-folder']")
     add_to_new_folder_link = (By.CSS_SELECTOR, "button[value='move-to-new-folder']")
@@ -497,7 +497,6 @@ class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
 
     def click_template_by_link_text(self, link_text):
         element = self.wait_for_element(self.template_link_text(link_text))
-        self.scrollToRevealElement(xpath=self.template_link_text(link_text)[1])
         element.click()
 
     def _select_template_type(self, type):


### PR DESCRIPTION
We've updated collapsible checkboxes markup and removed sticky button. Test need updating to not trigger that javascript function and click the correct button.

Before
![Screenshot 2024-09-03 at 13 03 28](https://github.com/user-attachments/assets/d659a365-7a97-46a0-8e0a-adc7c5601480)


After
![Screenshot 2024-09-03 at 13 00 12](https://github.com/user-attachments/assets/587a8320-e142-4b6f-8bc3-022b403b038f)
