### PR TITLE
Increase timeout before failing letter sending smoke test

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ config = {
     "pdf_generation_retry_interval": 1,
     "verify_callback_retry_times": 5,
     "verify_callback_retry_interval": 0.5,
-    "letter_retry_times": 48,
+    "letter_retry_times": 108,
     "provider_retry_times": 12,
     "provider_retry_interval": 22,
     "verify_code_retry_times": 8,


### PR DESCRIPTION
Increases the timeout from 4 minutes (48 retries with 5 seconds between them) to 9 minutes (108 retries with 5 seconds between them).

Letter sending is less time-sensitive than other types of notifications, so we don't want to be alerted unless the delay is significant. The smoke tests run every 10 minutes, so we don't want each run of the test to take longer than that.