### PR TITLE
Add unsubscribe request functional tests

### DIFF
--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -24,6 +24,7 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
+    dashboard_email_unsubscribe_stats_before = dashboard_page.get_email_unsubscribe_requests_count()
 
     # Send the notification via api
     send_notification_to_one_recipient(
@@ -56,6 +57,8 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     # Go to Email unsubscribe requests summary page
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
+    dashboard_email_unsubscribe_stats_after = dashboard_page.get_email_unsubscribe_requests_count()
+    assert dashboard_email_unsubscribe_stats_after > dashboard_email_unsubscribe_stats_before
     dashboard_page.click_email_unsubscribe_requests()
 
     # Go to email unsubscribe request report page

--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -1,0 +1,35 @@
+import os
+import uuid
+
+from config import config
+from tests.pages import DashboardPage
+from tests.test_utils import create_email_template, go_to_templates_page, recordtime, send_notification_to_one_recipient
+
+
+@recordtime
+def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_live_key):
+    # Create a subscription template
+    go_to_templates_page(driver)
+    template_name = f"functional subscription email template {uuid.uuid4()}"
+    content = "Hi ((name)), Is ((email address)) your email address? We want to send you some ((things))"
+    template_id = create_email_template(driver, name=template_name, content=content, has_unsubscribe_link=True)
+
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
+
+    # Send the notification via api
+    send_notification_to_one_recipient(
+        driver,
+        template_name,
+        "email",
+        test=False,
+        recipient_data=os.environ["FUNCTIONAL_TEST_EMAIL"],
+        placeholders_number=2,
+    )
+
+    dashboard_page.click_continue()
+    notification_id = dashboard_page.get_notification_id()
+    one_off_email_data = client_live_key.get_notification_by_id(notification_id)
+    #generated_one_click_unsubscribe_url = one_off_email_data["one_click_unsubscribe_url"]
+
+    assert one_off_email_data["template"]["id"] == template_id

--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -1,8 +1,9 @@
 import os
 import uuid
+from urllib.parse import urljoin, urlparse
 
-from config import config
-from tests.pages import DashboardPage
+from config import config, urls
+from tests.pages import DashboardPage, UnsubscribeRequestConfirmationPage
 from tests.test_utils import create_email_template, go_to_templates_page, recordtime, send_notification_to_one_recipient
 
 
@@ -17,7 +18,7 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
 
-    # Send the notification via api
+    # Send the notification
     send_notification_to_one_recipient(
         driver,
         template_name,
@@ -30,6 +31,18 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
     dashboard_page.click_continue()
     notification_id = dashboard_page.get_notification_id()
     one_off_email_data = client_live_key.get_notification_by_id(notification_id)
-    #generated_one_click_unsubscribe_url = one_off_email_data["one_click_unsubscribe_url"]
-
+    generated_one_click_unsubscribe_url = one_off_email_data["one_click_unsubscribe_url"]
     assert one_off_email_data["template"]["id"] == template_id
+
+    # simulate an unsubscribe request via the one click unsubscribe email header
+    resp = client_live_key.post(generated_one_click_unsubscribe_url, data={})
+    assert resp == {"result": "success", "message": "Unsubscribe successful"}
+
+    # simulate an unsubscribe request via the one click unsubscribe url in the body of the email
+    path = urlparse(generated_one_click_unsubscribe_url).path
+    admin_url = urljoin(urls[os.environ["ENVIRONMENT"]]["admin"], path)
+    driver.get(admin_url)
+
+    unsubscribe_request_confirmation_page = UnsubscribeRequestConfirmationPage(driver)
+    unsubscribe_request_confirmation_page.click_confirm()
+    assert urlparse(driver.current_url).path == "/unsubscribe/confirmed"

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -8,6 +8,7 @@ class CommonPageLocators:
     CONTINUE_BUTTON = (By.CSS_SELECTOR, "main button.govuk-button")
     ACCEPT_COOKIE_BUTTON = (By.CLASS_NAME, "notify-cookie-banner__button-accept")
     H1 = (By.TAG_NAME, "H1")
+    BACK_LINK = (By.LINK_TEXT, "Back")
 
 
 class MainPageLocators:

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -55,6 +55,7 @@ class TemplatePageLocators:
 class EditTemplatePageLocators:
     TEMPLATE_SUBJECT_INPUT = (By.NAME, "subject")
     TEMPLATE_CONTENT_INPUT = (By.NAME, "template_content")
+    ADD_UNSUBSCRIBE_LINK_CHECKBOX = (By.CSS_SELECTOR, "input[type=checkbox]")
     SAVE_BUTTON = (By.CSS_SELECTOR, "main button.govuk-button")
     DELETE_BUTTON = (By.LINK_TEXT, "Delete this template")
     CONFIRM_DELETE_BUTTON = (By.NAME, "delete")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1224,3 +1224,11 @@ class ManageAttachmentPage(BasePage):
         delete_button.click()
         confirm_button = self.wait_for_element(self.confirm_button)
         confirm_button.click()
+
+
+class UnsubscribeRequestConfirmationPage(BasePage):
+    confirm_unsubscription_button = (By.CSS_SELECTOR, "button[type=submit]")
+
+    def click_confirm(self):
+        element = self.wait_for_element(UnsubscribeRequestConfirmationPage.confirm_unsubscription_button)
+        element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -693,6 +693,7 @@ class ViewTemplatePage(BasePage):
 class EditEmailTemplatePage(BasePage):
     name_input = NameInputElement(clear=True)
     subject_input = SubjectInputElement(clear=True)
+    add_unsubscribe_link = EditTemplatePageLocators.ADD_UNSUBSCRIBE_LINK_CHECKBOX
     template_content_input = TemplateContentElement(clear=True)
     save_button = EditTemplatePageLocators.SAVE_BUTTON
     delete_button = EditTemplatePageLocators.DELETE_BUTTON
@@ -705,6 +706,10 @@ class EditEmailTemplatePage(BasePage):
             f"//a[contains(@class,'folder-heading-folder')]/text()[contains(.,'{folder_name}')]/..",
         )
 
+    def select_add_an_usubscribe_link_checkbox(self):
+        element = self.wait_for_design_system_checkbox_or_radio(EditEmailTemplatePage.add_unsubscribe_link)
+        self.select_checkbox_or_radio(element)
+
     def click_save(self):
         element = self.wait_for_element(EditEmailTemplatePage.save_button)
         element.click()
@@ -715,9 +720,17 @@ class EditEmailTemplatePage(BasePage):
         element = self.wait_for_element(EditEmailTemplatePage.confirm_delete_button)
         element.click()
 
-    def fill_template(self, name="Test email template", subject="Test email from functional tests", content=None):
+    def fill_template(
+        self,
+        name="Test email template",
+        subject="Test email from functional tests",
+        content=None,
+        has_unsubscribe_link=False,
+    ):
         self.name_input = name
         self.subject_input = subject
+        if has_unsubscribe_link:
+            self.select_add_an_usubscribe_link_checkbox()
         if content:
             self.template_content_input = content
         else:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -236,6 +236,10 @@ class BasePage:
         errors = self.wait_for_element(error_message)
         return errors.text.strip()
 
+    def click_back_link(self):
+        element = self.wait_for_element(CommonPageLocators.BACK_LINK)
+        element.click()
+
 
 class PageWithStickyNavMixin:
     def scrollToRevealElement(self, selector=None, xpath=None, stuckToBottom=True):
@@ -383,6 +387,7 @@ class DashboardPage(BasePage):
     total_letter_div = (By.CSS_SELECTOR, "#total-letters .big-number-number")
     inbox_link = (By.CSS_SELECTOR, "#total-received")
     navigation = (By.CLASS_NAME, "navigation")
+    email_unsubscribe_requests_link = (By.CSS_SELECTOR, "#total-unsubscribe-requests")
 
     def _message_count_for_template_div(self, template_id):
         return (By.ID, template_id)
@@ -409,6 +414,10 @@ class DashboardPage(BasePage):
 
     def click_inbox_link(self):
         element = self.wait_for_element(DashboardPage.inbox_link)
+        element.click()
+
+    def click_email_unsubscribe_requests(self):
+        element = self.wait_for_element(DashboardPage.email_unsubscribe_requests_link)
         element.click()
 
     def get_service_id(self):
@@ -1231,4 +1240,32 @@ class UnsubscribeRequestConfirmationPage(BasePage):
 
     def click_confirm(self):
         element = self.wait_for_element(UnsubscribeRequestConfirmationPage.confirm_unsubscription_button)
+        element.click()
+
+
+class UnsubscribeRequestReportsSummaryPage(BasePage):
+    unsubscribe_request_report_link = (By.CSS_SELECTOR, "th a")
+
+    def click_latest_unsubscribe_request_report_by_link(self):
+        element = self.wait_for_element(UnsubscribeRequestReportsSummaryPage.unsubscribe_request_report_link)
+        element.click()
+
+
+class UnsubscribeRequestReportPage(BasePage):
+    download_report_link = (By.LINK_TEXT, "Download the report")
+    mark_report_as_complete_checkbox = (By.CSS_SELECTOR, "input[type=checkbox]")
+    update_report_button = (By.CSS_SELECTOR, "button[type=submit]")
+
+    def click_download_report_link(self):
+        element = self.wait_for_element(UnsubscribeRequestReportPage.download_report_link)
+        element.click()
+
+    def select_mark_as_complete_checkbox(self):
+        element = self.wait_for_design_system_checkbox_or_radio(
+            UnsubscribeRequestReportPage.mark_report_as_complete_checkbox
+        )
+        self.select_checkbox_or_radio(element)
+
+    def click_update_button(self):
+        element = self.wait_for_element(UnsubscribeRequestReportPage.update_report_button)
         element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -388,6 +388,7 @@ class DashboardPage(BasePage):
     inbox_link = (By.CSS_SELECTOR, "#total-received")
     navigation = (By.CLASS_NAME, "navigation")
     email_unsubscribe_requests_link = (By.CSS_SELECTOR, "#total-unsubscribe-requests")
+    email_unsubscribe_requests_count_link = (By.CSS_SELECTOR, "#total-unsubscribe-requests .banner-dashboard-count")
 
     def _message_count_for_template_div(self, template_id):
         return (By.ID, template_id)
@@ -450,6 +451,11 @@ class DashboardPage(BasePage):
     def get_template_message_count(self, template_id):
         messages_sent_count_for_template_div = self._message_count_for_template_div(template_id)
         element = self.wait_for_element(messages_sent_count_for_template_div)
+
+        return int(element.text)
+
+    def get_email_unsubscribe_requests_count(self):
+        element = self.wait_for_element(DashboardPage.email_unsubscribe_requests_count_link)
 
         return int(element.text)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -223,14 +223,14 @@ def is_view_for_all_permissions(page):
     assert page.driver.current_url == expected
 
 
-def create_email_template(driver, name, content=None):
+def create_email_template(driver, name, content=None, has_unsubscribe_link=False):
     show_templates_page = ShowTemplatesPage(driver)
     show_templates_page.click_add_new_template()
 
     show_templates_page.select_email()
 
     template_page = EditEmailTemplatePage(driver)
-    template_page.fill_template(name=name, content=content)
+    template_page.fill_template(name=name, content=content, has_unsubscribe_link=has_unsubscribe_link)
     return template_page.get_template_id()
 
 


### PR DESCRIPTION
This PR adds a functional test that covers the entire email unsubscribe request journey as shown in [this ](https://trello.com/c/7ngdhTeg/80-add-a-functional-test-for-the-manual-email-unsubscribe-process)card.

The only thing not addressed explicitly in this PR is the cleanup of the unsubscribe requests generated. Instead this PR is relying on the fact that the unsubscribe requests generated will be archived after 7 days, https://github.com/alphagov/notifications-api/blob/a648d502cfc9d782145622b54f25f8262c1c963e/app/celery/nightly_tasks.py#L79

Each time the test runs, two unsubscribe requests are generated one for each pathway an unsubscribe request is generated ie. either via the the link in the email header or in the body of the email.
