### PR TITLE
Fix a potential KeyError in inbound SMS test

### DIFF
--- a/tests/functional/preview_and_dev/test_inbound_sms.py
+++ b/tests/functional/preview_and_dev/test_inbound_sms.py
@@ -72,7 +72,7 @@ def assert_callback_received(inbound_sms):
 
     recent_callback_requests = [item["event"] for item in response.json()["data"]]
     matching_callback_requests = [
-        request for request in recent_callback_requests if request["body"]["message"] == inbound_sms
+        request for request in recent_callback_requests if request.get("body", {}).get("message") == inbound_sms
     ]
 
     assert len(matching_callback_requests) == 1


### PR DESCRIPTION
This can happen if any of the requests captured by Pipedream have no body. I think this is the cause of the failure in https://concourse.notify.tools/teams/notify/pipelines/notify-infra/jobs/run-terraform-preview/builds/955.

(From local testing I can see that 1 of the past 10 requests captured by Pipedream has no body)