### PR TITLE
Restore changes to ShowTemplatesPage class

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -445,7 +445,7 @@ class DashboardPage(BasePage):
         return int(element.text)
 
 
-class ShowTemplatesPage(BasePage):
+class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
     add_new_template_link = (By.CSS_SELECTOR, "button[value='add-new-template']")
     add_new_folder_link = (By.CSS_SELECTOR, "button[value='add-new-folder']")
     add_to_new_folder_link = (By.CSS_SELECTOR, "button[value='move-to-new-folder']")
@@ -497,6 +497,7 @@ class ShowTemplatesPage(BasePage):
 
     def click_template_by_link_text(self, link_text):
         element = self.wait_for_element(self.template_link_text(link_text))
+        self.scrollToRevealElement(xpath=self.template_link_text(link_text)[1])
         element.click()
 
     def _select_template_type(self, type):


### PR DESCRIPTION
Bring back some of the changes removed in https://github.com/alphagov/notifications-functional-tests/pull/520

Their removal was a red-hearing fix. Actual fix was a CSS change in admin https://github.com/alphagov/notifications-admin/pull/5159

These are needed for sticky nav to work on the templates page.