### PR TITLE
Treat absence of banner as ‘0’ unsubscribe requests

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -455,7 +455,10 @@ class DashboardPage(BasePage):
         return int(element.text)
 
     def get_email_unsubscribe_requests_count(self):
-        element = self.wait_for_element(DashboardPage.email_unsubscribe_requests_count_link)
+        try:
+            element = self.wait_for_element(DashboardPage.email_unsubscribe_requests_count_link)
+        except (NoSuchElementException, TimeoutException):
+            return 0
 
         return int(element.text)
 


### PR DESCRIPTION
The banner only shows if there are some requests in the last 7 days.

At the moment the tests treat absence of the banner as a failure.

This will be a problem if the tests haven’t run in a while and all the previous unsubscribe requests have been cleaned up (they automatically get deleted after 7 days).

This commit changes the tests to treat absence of the banner as equivalent to ‘0’ requests (which is true). This means they can continue to the next step which is creating the first request.

We have plenty of other examples of this pattern elsewhere in the tests, for example:
https://github.com/alphagov/notifications-functional-tests/blob/74282fb66b8b13b3eb978128511f9450c04f2420/tests/pages/pages.py#L271-L274