### PR TITLE
Use config to get app URLs

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,31 +41,29 @@ config = {
 }
 
 
-urls = {
-    "dev": {
-        "api": os.environ.get("FUNCTIONAL_TESTS_LOCAL_API_HOST", "http://localhost:6011"),
-        "admin": os.environ.get("FUNCTIONAL_TESTS_LOCAL_ADMIN_HOST", "http://localhost:6012"),
-    },
-    "preview": {
-        "api": "https://api.notify.works",
-        "admin": "https://www.notify.works",
-    },
-    "staging": {
-        "api": "https://api.staging-notify.works",
-        "admin": "https://www.staging-notify.works",
-    },
-    "live": {
-        "api": "https://api.notifications.service.gov.uk",
-        "admin": "https://www.notifications.service.gov.uk",
-    },
-}
-
-
 def setup_shared_config():
     """
     Used by all tests
     """
     env = os.environ["ENVIRONMENT"].lower()
+    urls = {
+        "dev": {
+            "api": os.environ.get("FUNCTIONAL_TESTS_LOCAL_API_HOST", "http://localhost:6011"),
+            "admin": os.environ.get("FUNCTIONAL_TESTS_LOCAL_ADMIN_HOST", "http://localhost:6012"),
+        },
+        "preview": {
+            "api": "https://api.notify.works",
+            "admin": "https://www.notify.works",
+        },
+        "staging": {
+            "api": "https://api.staging-notify.works",
+            "admin": "https://www.staging-notify.works",
+        },
+        "live": {
+            "api": "https://api.notifications.service.gov.uk",
+            "admin": "https://www.notifications.service.gov.uk",
+        },
+    }
 
     if env not in {"dev", "preview", "staging", "live"}:
         if not os.environ.get("FUNCTIONAL_TESTS_API_HOST") or not os.environ.get("FUNCTIONAL_TESTS_ADMIN_HOST"):

--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin, urlparse
 
 from selenium.webdriver.common.by import By
 
-from config import config, urls
+from config import config
 from tests.pages import (
     DashboardPage,
     UnsubscribeRequestConfirmationPage,
@@ -48,7 +48,7 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     # simulate an unsubscribe request via the one click unsubscribe url in the body of the email
     path = urlparse(generated_one_click_unsubscribe_url).path
-    admin_url = urljoin(urls[os.environ["ENVIRONMENT"]]["admin"], path)
+    admin_url = urljoin(config["notify_admin_url"], path)
     driver.get(admin_url)
 
     unsubscribe_request_confirmation_page = UnsubscribeRequestConfirmationPage(driver)


### PR DESCRIPTION
The config setup does some extra work to set the URLs for dev environments:
https://github.com/alphagov/notifications-functional-tests/blob/74282fb66b8b13b3eb978128511f9450c04f2420/config.py#L77-L83

This is missed if the mapping of environment name to URL is used directly.

This causes the test to fail in `dev-a`.