### PR TITLE
Update test_unsubscribe_request_flow

### DIFF
--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -24,7 +24,6 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
-    dashboard_email_unsubscribe_stats_before = dashboard_page.get_email_unsubscribe_requests_count()
 
     # Send the notification via api
     send_notification_to_one_recipient(
@@ -46,6 +45,9 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
     resp = client_live_key.post(generated_one_click_unsubscribe_url, data={})
     assert resp == {"result": "success", "message": "Unsubscribe successful"}
 
+    dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
+    dashboard_email_unsubscribe_stats_1 = dashboard_page.get_email_unsubscribe_requests_count()
+
     # simulate an unsubscribe request via the one click unsubscribe url in the body of the email
     path = urlparse(generated_one_click_unsubscribe_url).path
     admin_url = urljoin(config["notify_admin_url"], path)
@@ -57,8 +59,8 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     # Go to Email unsubscribe requests summary page
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])
-    dashboard_email_unsubscribe_stats_after = dashboard_page.get_email_unsubscribe_requests_count()
-    assert dashboard_email_unsubscribe_stats_after > dashboard_email_unsubscribe_stats_before
+    dashboard_email_unsubscribe_stats_2 = dashboard_page.get_email_unsubscribe_requests_count()
+    assert dashboard_email_unsubscribe_stats_2 > dashboard_email_unsubscribe_stats_1
     dashboard_page.click_email_unsubscribe_requests()
 
     # Go to email unsubscribe request report page


### PR DESCRIPTION
 The check on the email unsubscribe request count displayed on the dashboard has now been adjusted to check the increment to the count from the first received
 unsubscribe request to the second received unsubscribe request.
 The initial assertion was brittle because of the possibility the banner the test relies on to extract the count may not be available if previously generated unsubscribe requests have been cleaned up
 after 7 days or the test is run against a new instance of a dev environment which would not have prepopulated unsubscribe request(s). This adjustment guarantees that the banner would always be available.