### PR TITLE
Remove first parameter for add_service endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.2.0

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -305,7 +305,7 @@ class AddServicePage(BasePage):
     add_service_button = AddServicePageLocators.ADD_SERVICE_BUTTON
 
     def wait_until_current(self):
-        return self.wait_until_url_is(self.base_url + "/add-service?first=first")
+        return self.wait_until_url_is(self.base_url + "/add-service")
 
     def add_service(self, name):
         self.service_input = name


### PR DESCRIPTION
Updating `"/add-service?first=first"` to `"/add-service"` because we refactored endpoint in admin. https://github.com/alphagov/notifications-admin/pull/5295