### PR TITLE
remove pytest-rerunfailures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ markers =
     template_preview: mark a tests to run for template-preview builds.
     antivirus: mark a test to run for antivirus builds.
 
-reruns = 3
+reruns = 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ markers =
     antivirus: mark a test to run for antivirus builds.
 
 reruns = 0
-addopts = -x
+addopts = -x -vvv

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ markers =
     antivirus: mark a test to run for antivirus builds.
 
 reruns = 0
+addopts = -x


### PR DESCRIPTION
removes reruns - we're worried that this will lead to inconsistent state, particularly in tests that start with signing up a new user. If that fails, then we don't see anything, and can end up with lots of questions such as:

* What error did we get?
* Why did it fail
* What page is it on now, and does the unit test assume that it's on a particular page at the start of the function?
* which artifacts of the functional tests (eg user accounts, services, templates) have been created?
* If we retry will it try and recreate those when re-running, will Notify handle that or throw an error?

I've decided that I'd rather understand our failures rather than try and just smooth over them

If it means we need to bump up some individual function retries on things that sometimes time out (eg letter creation), that is much more preferable even if it might mean a little more churn in editing this repo

during deploy-api-preview at least, we still retry the entire functional test suite - this might take a bit longer if things flake once, but means we'll actually get a stack trace we can look at to figure out why each individual test is failing