### PR TITLE
always wait before checking current_url

### DIFF
--- a/tests/functional/preview_and_dev/test_email_auth.py
+++ b/tests/functional/preview_and_dev/test_email_auth.py
@@ -16,9 +16,9 @@ from tests.test_utils import do_email_verification, recordtime
 def test_email_auth(driver):
     # login email auth user
     sign_in_email_auth(driver)
-    # assert url is FUNCTIONAL_TESTS_SERVICE's dashboard
-    assert driver.current_url == config["notify_admin_url"] + "/services/{}".format(config["service"]["id"])
     base_page = BasePage(driver)
+    # assert url is FUNCTIONAL_TESTS_SERVICE's dashboard
+    base_page.wait_until_url_contains(f"/services/{config['service']['id']}")
     base_page.sign_out()
 
 

--- a/tests/functional/preview_and_dev/test_join_live_service.py
+++ b/tests/functional/preview_and_dev/test_join_live_service.py
@@ -36,7 +36,7 @@ def _do_request_to_join_service(driver):
     add_service_page.wait_until_current()
     add_service_page.join_live_service()
 
-    assert driver.current_url == config["notify_admin_url"] + "/join-a-service/choose"
+    add_service_page.wait_until_url_contains("/join-a-service/choose")
 
     choose_service_page = ServiceJoinRequestChooseServicePage(driver)
     if choose_service_page.check_if_search_input_exists():
@@ -48,7 +48,7 @@ def _do_request_to_join_service(driver):
     join_ask_page.request_reason_input = "Test join service reason"
     join_ask_page.ask_to_join_service()
 
-    assert "/join/you-have-asked?number_of_users_emailed=1" in driver.current_url
+    join_ask_page.wait_until_url_contains("/join/you-have-asked?number_of_users_emailed=1")
 
     add_service_page.sign_out()
 
@@ -63,9 +63,7 @@ def _do_approver_approved_request(driver):
     choose_permissions_page.fill_invitation_form()
     choose_permissions_page.select_sms_auth_form()
     choose_permissions_page.save_permissions()
-    choose_permissions_page.wait_until_url_is(config["notify_admin_url"] + "/your-services")
-
-    assert driver.current_url == config["notify_admin_url"] + "/your-services"
+    choose_permissions_page.wait_until_url_contains("/your-services")
 
     choose_permissions_page.sign_out()
 
@@ -77,9 +75,7 @@ def _do_approver_rejected_request(driver):
     join_service_request_approve_page.select_rejected_option()
     join_service_request_approve_page.continue_to_next_step()
 
-    join_service_request_approve_page.wait_until_url_is("/refused")
-
-    assert "/refused" in driver.current_url
+    join_service_request_approve_page.wait_until_url_contains("/refused")
 
     join_service_request_approve_page.sign_out()
 

--- a/tests/functional/preview_and_dev/test_org_invite.py
+++ b/tests/functional/preview_and_dev/test_org_invite.py
@@ -31,7 +31,7 @@ def test_org_invite(driver, login_seeded_user):
     # now log out and create account as invited user
     dashboard_page = DashboardPage(driver)
     dashboard_page.sign_out()
-    dashboard_page.wait_until_url_is(config["notify_admin_url"])
+    dashboard_page.wait_until_url_contains(config["notify_admin_url"])
 
     invite_link = get_link(config["notify_templates"]["org_invitation_template_id"], invited_user_email)
     driver.get(invite_link)

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -31,7 +31,7 @@ def _sign_in_again(driver):
     # sign back in as the original service user
     dashboard_page = DashboardPage(driver)
     dashboard_page.sign_out()
-    dashboard_page.wait_until_url_is(config["notify_admin_url"])
+    dashboard_page.wait_until_url_contains(config["notify_admin_url"])
 
     sign_in(driver, account_type="normal")
 

--- a/tests/functional/preview_and_dev/test_unsubscribe_requests.py
+++ b/tests/functional/preview_and_dev/test_unsubscribe_requests.py
@@ -55,7 +55,7 @@ def test_unsubscribe_request_flow(request, driver, login_seeded_user, client_liv
 
     unsubscribe_request_confirmation_page = UnsubscribeRequestConfirmationPage(driver)
     unsubscribe_request_confirmation_page.click_confirm()
-    assert urlparse(driver.current_url).path == "/unsubscribe/confirmed"
+    unsubscribe_request_confirmation_page.wait_until_url_contains("/unsubscribe/confirmed")
 
     # Go to Email unsubscribe requests summary page
     dashboard_page.go_to_dashboard_for_service(service_id=config["service"]["id"])

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -187,7 +187,7 @@ class BasePage:
 
         self.driver.delete_all_cookies()
 
-    def wait_until_url_is(self, url):
+    def wait_until_url_contains(self, url):
         return WebDriverWait(self.driver, 10).until(self.url_contains(url))
 
     def url_contains(self, url):
@@ -238,6 +238,7 @@ class BasePage:
         # e.g.
         # http://localhost:6012/services/237dd966-b092-42ab-b406-0a00187d007f/templates/4808eb34-5225-492b-8af2-14b232f05b8e/edit
         # circle back and do better
+        self.wait_until_url_contains("/templates/")
         return self.driver.current_url.split("/templates/")[1].split("/")[0]
 
     def click_element_by_link_text(self, link_text):
@@ -302,7 +303,7 @@ class RegistrationPage(BasePage):
     password_input = PasswordInputElement()
 
     def wait_until_current(self):
-        return self.wait_until_url_is(self.base_url + "/register")
+        return self.wait_until_url_contains(self.base_url + "/register")
 
     def register(self):
         self.name_input = config["user"]["name"]
@@ -318,7 +319,7 @@ class AddServicePage(BasePage):
     add_service_button = AddServicePageLocators.ADD_SERVICE_BUTTON
 
     def wait_until_current(self):
-        return self.wait_until_url_is(self.base_url + "/add-service")
+        return self.wait_until_url_contains(self.base_url + "/add-service")
 
     def add_service(self, name):
         self.service_input = name
@@ -346,7 +347,7 @@ class YourServicesPage(BasePage):
     add_a_new_service_button = YourServicesPageLocators.ADD_A_NEW_SERVICE_BUTTON
 
     def wait_until_current(self):
-        return self.wait_until_url_is(self.base_url + "/your-service")
+        return self.wait_until_url_contains(self.base_url + "/your-service")
 
     def join_live_service(self):
         element = self.wait_for_element(YourServicesPage.join_live_service_button)
@@ -460,7 +461,7 @@ class SignInPage(BasePage):
         self.driver.get(self.base_url + "/sign-in")
 
     def wait_until_current(self):
-        return self.wait_until_url_is(self.base_url + "/sign-in")
+        return self.wait_until_url_contains(self.base_url + "/sign-in")
 
     def fill_login_form(self, email, password):
         self.email_input = email
@@ -503,8 +504,9 @@ class DashboardPage(BasePage):
         return (By.ID, template_id)
 
     def is_current(self, service_id):
-        expected = f"{self.base_url}/services/{service_id}/dashboard"
-        return self.driver.current_url == expected
+        expected = f"/services/{service_id}/dashboard"
+        self.wait_until_url_contains(expected)
+        return True
 
     def get_service_name(self):
         element = self.wait_for_element(DashboardPage.h2)
@@ -531,6 +533,7 @@ class DashboardPage(BasePage):
         element.click()
 
     def get_service_id(self):
+        self.wait_until_url_contains("/services/")
         return self.driver.current_url.split("/services/")[1].split("/")[0]
 
     def get_navigation_list(self):
@@ -538,6 +541,7 @@ class DashboardPage(BasePage):
         return element.text
 
     def get_notification_id(self):
+        self.wait_until_url_contains("/notification/")
         return self.driver.current_url.split("notification/")[1].split("?")[0]
 
     def go_to_dashboard_for_service(self, service_id=None):
@@ -1211,7 +1215,8 @@ class OrganisationDashboardPage(BasePage):
 
     def is_current(self, org_id):
         expected = f"{self.base_url}/organisations/{org_id}"
-        return self.driver.current_url == expected
+        self.wait_until_url_contains(expected)
+        return True
 
     def click_team_members_link(self):
         element = self.wait_for_element(DashboardPage.team_members_link)
@@ -1237,7 +1242,8 @@ class InviteUserToOrgPage(BasePage):
 class InboxPage(BasePage):
     def is_current(self, service_id):
         expected = f"{self.base_url}/services/{service_id}/inbox"
-        return self.driver.current_url == expected
+        self.wait_until_url_contains(expected)
+        return True
 
     def go_to_conversation(self, user_number):
         # link looks like "07123 456789". because i don't know if user_number starts with +44, just get the last 10

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,12 +140,12 @@ def do_email_verification(driver, template_id, email_address):
 
 
 def do_user_add_new_service(driver):
-    # TODO: Check which one of these we expect to happen - your-services or add service page?
-    # we should only have one on all envs ideally
-    if driver.current_url == config["notify_admin_url"] + "/your-services":
-        your_service_page = YourServicesPage(driver)
-        your_service_page.wait_until_current()
-        your_service_page.add_new_service()
+    your_service_page = YourServicesPage(driver)
+    # for functional tests to run, there needs to be a functional test organisation that:
+    # * has the `ask to join a service` flag enabled
+    # * has the functional tests email domain (by default digital.cabinet-office.gov.uk) set as a known domain
+    your_service_page.wait_until_current()
+    your_service_page.add_new_service()
 
     add_service_page = AddServicePage(driver)
     add_service_page.wait_until_current()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,10 +98,10 @@ def get_link(template_id, email):
     delay=config["verify_code_retry_interval"],
 )
 def do_verify(driver, mobile_number):
+    verify_code = get_verify_code_from_api(mobile_number)
+    verify_page = VerifyPage(driver)
+    verify_page.verify(verify_code)
     try:
-        verify_code = get_verify_code_from_api(mobile_number)
-        verify_page = VerifyPage(driver)
-        verify_page.verify(verify_code)
         driver.find_element(By.CLASS_NAME, "error-message")
     except (NoSuchElementException, TimeoutException):
         #  In some cases a TimeoutException is raised even if we have managed to verify.
@@ -140,6 +140,8 @@ def do_email_verification(driver, template_id, email_address):
 
 
 def do_user_add_new_service(driver):
+    # TODO: Check which one of these we expect to happen - your-services or add service page?
+    # we should only have one on all envs ideally
     if driver.current_url == config["notify_admin_url"] + "/your-services":
         your_service_page = YourServicesPage(driver)
         your_service_page.wait_until_current()
@@ -166,7 +168,7 @@ def do_user_registration(driver):
 
     registration_page.register()
 
-    assert driver.current_url == config["notify_admin_url"] + "/registration-continue"
+    registration_page.wait_until_url_contains("/registration-continue")
 
     registration_link = get_link(config["notify_templates"]["registration_template_id"], config["user"]["email"])
 
@@ -195,7 +197,7 @@ def do_user_can_invite_someone_to_notify(driver, basic_view):
 
     invite_user_page.send_invitation()
     invite_user_page.sign_out()
-    invite_user_page.wait_until_url_is(config["notify_admin_url"])
+    invite_user_page.wait_until_url_contains(config["notify_admin_url"])
 
     # next part of interaction is from point of view of invitee
     # i.e. after visting invite_link we'll be registering using invite_email
@@ -221,14 +223,13 @@ def do_user_can_invite_someone_to_notify(driver, basic_view):
 
 def is_basic_view(dashboard_page):
     assert dashboard_page.get_navigation_list() == "Templates\nSent messages\nUploads\nTeam members"
-    expected = f"{dashboard_page.base_url}/services/{dashboard_page.get_service_id()}/templates"
-    assert dashboard_page.driver.current_url == expected
+    assert dashboard_page.wait_until_url_contains(f"/services/{dashboard_page.get_service_id()}/templates")
 
 
 def is_view_for_all_permissions(page):
     assert page.get_navigation_list() == "Dashboard\nTemplates\nUploads\nTeam members\nUsage\nSettings\nAPI integration"
-    expected = f"{page.base_url}/services/{page.get_service_id()}"
-    assert page.driver.current_url == expected
+    expected = f"/services/{page.get_service_id()}"
+    assert page.wait_until_url_contains(expected)
 
 
 def create_email_template(driver, name, content=None, has_unsubscribe_link=False):


### PR DESCRIPTION
current_url only reflects what the browser URL is at that point in time

if there's a request in flight, for example you only just clicked a submit button on a form, current_url will still be the old URL. Instead of just asserting on current_url, or making code branch decisions based on it, we should instead use `wait_until_url_contains` which will wait up to ten seconds for the URL to load.

This should hopefully reduce weird flakiness around URL checking and retrieving the service_id from URLs