### PR TITLE
Login retry

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -188,13 +188,10 @@ class BasePage:
         self.driver.delete_all_cookies()
 
     def wait_until_url_contains(self, url):
-        return WebDriverWait(self.driver, 10).until(self.url_contains(url))
+        return WebDriverWait(self.driver, 10).until(lambda _: url in self.driver.current_url)
 
-    def url_contains(self, url):
-        def check_contains_url(driver):
-            return url in self.driver.current_url
-
-        return check_contains_url
+    def wait_until_url_doesnt_contain(self, url):
+        return WebDriverWait(self.driver, 10).until(lambda _: url not in self.driver.current_url)
 
     def select_checkbox_or_radio(self, element=None, value=None):
         if not element and value:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -482,6 +482,22 @@ class VerifyPage(BasePage):
         self.sms_input = code
         self.click_continue()
 
+    def verify_code_successful(self) -> bool:
+        try:
+            # override the default 10 seconds to keep things a bit snappier
+            self.wait_for_element((By.CLASS_NAME, "error-message"), time=2)
+        except (NoSuchElementException, TimeoutException):
+            # if we cant find the error message, it's probs because we succesfully redirected! but lets double check
+            try:
+                self.wait_until_url_doesnt_contain("/verify")  # times out if we were unsuccesful
+                return True
+            except TimeoutException:
+                # we expect to have been redirected away from the `/verify` URL, so we should retry
+                return False
+        else:
+            # found an error message on the page, so should retry
+            return False
+
 
 class DashboardPage(BasePage):
     h2 = (By.CLASS_NAME, "navigation-service-name")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,14 +101,7 @@ def do_verify(driver, mobile_number):
     verify_code = get_verify_code_from_api(mobile_number)
     verify_page = VerifyPage(driver)
     verify_page.verify(verify_code)
-    try:
-        driver.find_element(By.CLASS_NAME, "error-message")
-    except (NoSuchElementException, TimeoutException):
-        #  In some cases a TimeoutException is raised even if we have managed to verify.
-        #  For now, check explicitly if we 'have verified' and if so move on.
-        return True
-    else:
-        #  There was an error message so let's retry
+    if not verify_page.verify_code_successful():
         raise RetryException
 
 


### PR DESCRIPTION
### tidy up url_contains and url_doesnt_contain webdriverwait checks


### make 2fa sms code logic more robust

i have a theory that it was finding a race condition where the login would fail, but the bit of code where it tries to find the error-message would fail to find the element _before_ the page had reloaded and error message could be rendered.

my gut says that anywhere we say "driver.find_element" without using a `WebDriverWait` could be suceptible to this too, unless we're confident the page has already finished loading.

change the login so that if it cant find the error message, it checks to make sure we're on a different page (which would indicate that we logged in succesfully)
