### PR TITLE
fix url checking in verify step

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,13 +74,14 @@ def driver(_driver, request):
 
         # print last 20 events
         _driver._listener.print_events(num_to_print=20)
-        # wipe down for next test
-        _driver._listener.clear_events()
 
         filename_datetime = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         filename = str(Path.cwd() / "screenshots" / f"{filename_datetime}_{request.function.__name__}.png")
         _driver.save_screenshot(str(filename))
         print("Error screenshot saved to " + filename)  # noqa: T201
+
+    # clear old events/urls regardless of failure
+    _driver._listener.clear_events()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### always clear events from logging lib

we were only clearing the tests down after failed tests, whereas really it's clearing them down after successful tests that is important

### check for /verify and /two-factor-sms on verify page

verify for new user registration two-factor-sms for returning user sign-in

prev we were just checking for "does url not equal /verify" so got false positives on the user sign-in flow.

also parse url and check path for equality

rather than checking path in a whole URL, split the path.  this means we can be robust (and not accidentally match on URLs that look like `/verify-email` for example), while not getting false negatives if the URL includes, eg, query strings