### PR TITLE
Make smoke tests more lenient

### DIFF
--- a/config.py
+++ b/config.py
@@ -158,6 +158,9 @@ def setup_staging_prod_config():
     # staging and prod run the same simple smoke tests
     config.update(
         {
+            # the smoke tests send a CSV which might get stuck behind other jobs we allow
+            # these notifications to take longer (2m30s rather than the normal wait of 1m15s)
+            "smoke_test_csv_notification_retry_time": 30,
             "name": "{} Functional Tests".format(config["env"]),
             "user": {
                 "email": os.environ["FUNCTIONAL_TEST_EMAIL"],

--- a/tests/functional/staging_and_prod/test_admin.py
+++ b/tests/functional/staging_and_prod/test_admin.py
@@ -25,7 +25,7 @@ def test_admin(driver, client_live_key, login_user):
             csv_sms_notification_id,
             NotificationStatuses.SENT,
         ],
-        tries=config["notification_retry_times"],
+        tries=config["smoke_test_csv_notification_retry_time"],
         delay=config["notification_retry_interval"],
     )
     assert_notification_body(csv_sms_notification_id, csv_sms_notification)
@@ -38,7 +38,7 @@ def test_admin(driver, client_live_key, login_user):
             csv_email_notification_id,
             NotificationStatuses.SENT,
         ],
-        tries=config["notification_retry_times"],
+        tries=config["smoke_test_csv_notification_retry_time"],
         delay=config["notification_retry_interval"],
     )
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -902,8 +902,7 @@ class UploadCsvPage(BasePage):
         self.click_send()
         shutil.rmtree(directory, ignore_errors=True)
 
-    # we've been having issues with celery short polling causing notifications to take a long time.
-    @retry(RetryException, tries=10, delay=10)
+    @retry(RetryException, tries=20, delay=10)
     def get_notification_id_after_upload(self):
         try:
             element = self.wait_for_element(UploadCsvPage.first_notification)


### PR DESCRIPTION
### double timeout for csv uploads in smoke tests

sometimes, the smoke tests happen at the same time as a large upload of jobs, and the notifications are stuck in a queue behind that. if we wait twice as long for notifications to move to sending, that gives us an extra buffer for these cases.

when users upload jobs, our assumption is that it's not actually as important if that notification sends within 10 seconds (when compared to one-offs or api messages which may be part of synchronous user interactions like two factor codes). so it's okay if it takes a bit longer

### double the time we wait for job notifications to be created

sending a CSV we have two waits:

* wait for the notification to be created for the row
* wait for that notification to move from created into sending

make sure we bump the timeouts in both places

(also remove a comment about short polling, we haven't used celery short polling for years)
