### PR TITLE
Improved logging for multiple failing test cases

### DIFF
--- a/tests/functional/preview_and_dev/test_join_live_service.py
+++ b/tests/functional/preview_and_dev/test_join_live_service.py
@@ -12,14 +12,6 @@ from tests.pages.rollups import sign_in
 from tests.test_utils import do_user_registration, get_link, recordtime
 
 
-@pytest.fixture(scope="module", autouse=True)
-@recordtime
-def register_user(_driver):
-    # has to use _driver as this is at module level (`driver` fixture is at function level, and just handles taking
-    # the screenshot on failure)
-    do_user_registration(_driver)
-
-
 def _do_approver_sign_in(driver):
     requested_user_email = config["service"]["seeded_user"]["email"]
     sign_in(driver, account_type="seeded")
@@ -83,6 +75,7 @@ def _do_approver_rejected_request(driver):
 @recordtime
 @pytest.mark.xdist_group(name="join-service-request-flow")
 def test_join_live_service_rejected_flow(driver):
+    do_user_registration(driver)
     _do_request_to_join_service(driver)
     _do_approver_rejected_request(driver)
 

--- a/tests/functional/preview_and_dev/test_registration_and_invite.py
+++ b/tests/functional/preview_and_dev/test_registration_and_invite.py
@@ -18,15 +18,6 @@ from tests.test_utils import (
 )
 
 
-@pytest.fixture(scope="module", autouse=True)
-@recordtime
-def register_user(_driver):
-    # has to use _driver as this is at module level (`driver` fixture is at function level, and just handles taking
-    # the screenshot on failure)
-    do_user_registration(_driver)
-    do_user_add_new_service(_driver)
-
-
 def _sign_in_again(driver):
     # sign back in as the original service user
     dashboard_page = DashboardPage(driver)
@@ -42,6 +33,8 @@ def _sign_in_again(driver):
 @recordtime
 @pytest.mark.xdist_group(name="registration-flow")
 def test_invite_flow(driver):
+    do_user_registration(driver)
+    do_user_add_new_service(driver)
     do_user_can_invite_someone_to_notify(driver, basic_view=False)
 
     _sign_in_again(driver)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -344,7 +344,7 @@ class YourServicesPage(BasePage):
     add_a_new_service_button = YourServicesPageLocators.ADD_A_NEW_SERVICE_BUTTON
 
     def wait_until_current(self):
-        return self.wait_until_url_contains(self.base_url + "/your-service")
+        return self.wait_until_url_contains(self.base_url + "/your-services")
 
     def join_live_service(self):
         element = self.wait_for_element(YourServicesPage.join_live_service_button)


### PR DESCRIPTION
Improved logging for multiple failing test cases. Converted module scope to function scope for `test_join_live_service` and `test_registration_and_invite` because driver does not support multiple scopes for logging.