### PR TITLE
Update redirect when join-service-request approved

### DIFF
--- a/tests/functional/preview_and_dev/test_join_live_service.py
+++ b/tests/functional/preview_and_dev/test_join_live_service.py
@@ -63,7 +63,7 @@ def _do_approver_approved_request(driver):
     choose_permissions_page.fill_invitation_form()
     choose_permissions_page.select_sms_auth_form()
     choose_permissions_page.save_permissions()
-    choose_permissions_page.wait_until_url_contains("/your-services")
+    choose_permissions_page.wait_until_url_contains("/users")
 
     choose_permissions_page.sign_out()
 


### PR DESCRIPTION
Join a service - Change redirect from 'Your Services' page to 'Team members' page for approvers. The approver is currently re-directed to the ‘Your services’ page, which doesn’t feel like the best place to go after just adding a user to a specific service. Fixing the failing test for this PR: https://github.com/alphagov/notifications-admin/pull/5337