### PR TITLE
Two quality of life functional test tweaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from tests.pages.rollups import sign_in, sign_in_email_auth
 
 def pytest_addoption(parser):
     parser.addoption("--no-headless", action="store_true", default=False)
+    parser.addoption("--unique-screenshot-filenames", action="store_true", default=False)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -73,13 +74,18 @@ def driver(_driver, request):
     _driver._listener.set_node(request.node.name)
     yield _driver
     if prev_failed_tests != request.session.testsfailed:
-        print("URL at time of failure:", _driver.current_url)  # noqa: T201
+        print("URL at time of failure:", datetime.now().isoformat(), _driver.current_url)  # noqa: T201
 
         # print last 20 events
         _driver._listener.print_events(node=request.node.name, num_to_print=20)
 
-        filename_datetime = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        filename = str(Path.cwd() / "screenshots" / f"{filename_datetime}_{request.function.__name__}.png")
+        file = (
+            f"{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}_{request.function.__name__}.png"
+            if request.config.getoption("--unique-screenshot-filenames")
+            else "test_failure.png"
+        )
+
+        filename = str(Path.cwd() / "screenshots" / file)
         _driver.save_screenshot(str(filename))
         print("Error screenshot saved to " + filename)  # noqa: T201
 


### PR DESCRIPTION
Both make it slightly easier to manage debugging failing tests on concourse. The first fixes a regression in the list of previously visited URLs, and the second commit kind-of fixes screenshots sometimes not uploading.

### store events and url_history per node

when printing for a specific node (ie: a specific unit test), we were using filters and lambdas to extract the list of events/urls that match that given node.

when we added this code we accidentally broke the de-duplication code (`current_url != self._url_history[-1]` in `_add_event`). This was comparing the current_url to the url_history, but the string in url_history contained the node as well, so this check would never pass and we'd fill `_url_history` up with duplicate entries, reducing its usefulness.

To fix this, rather than changing that log, just change how we store the events to store them in a dictionary per-node instead, so we never need to do any filtering.

### save screenshots to a single filename by default

on concourse, if functional tests retry, and both test runs fail, then we'll end up with two separate failure screenshots. However, the concourse resource that puts these on s3 fails because it expects exactly one file[^1]. We could zip the screenshots and upload them all, but this makes it more awkward for a dev to download, extract, and view them rather than just clicking the link in concourse.

So for now, we can just splat over the first failure by having a static filename, and be sure that we'll only upload one. If you wanted to see a screenshot for the first failure, well, tough! sorry!

Because it's still useful to be able to save nice screenshots locally, add a new command line option to save them using verbose names. This can be triggered by running `pytest --unique-screenshot-filenames ...`

[^1]: https://github.com/concourse/s3-resource/issues/55
