### PR TITLE
Allow "Your profile" link to be found by different link text

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -75,7 +75,8 @@ class NavigationLocators:
     SIGN_OUT_LINK = (By.LINK_TEXT, "Sign out")
     TEMPLATES_LINK = (By.LINK_TEXT, "Templates")
     SETTINGS_LINK = (By.LINK_TEXT, "Settings")
-    PROFILE_LINK = (By.LINK_TEXT, "Your profile")
+    PROFILE_LINK = (By.LINK_TEXT, "Your account")
+    OLD_PROFILE_LINK = (By.LINK_TEXT, "Your profile")
 
 
 class TemplatePageLocators:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -126,6 +126,7 @@ class AntiStaleElementList(AntiStale):
 class BasePage:
     sign_out_link = NavigationLocators.SIGN_OUT_LINK
     profile_page_link = NavigationLocators.PROFILE_LINK
+    old_profile_page_link = NavigationLocators.OLD_PROFILE_LINK
 
     def __init__(self, driver):
         self.base_url = config["notify_admin_url"]
@@ -179,7 +180,10 @@ class BasePage:
         )
 
     def sign_out(self):
-        profile_page_link = self.wait_for_element(BasePage.profile_page_link)
+        try:
+            profile_page_link = self.wait_for_element(BasePage.profile_page_link)
+        except (NoSuchElementException, TimeoutException):
+            profile_page_link = self.wait_for_element(BasePage.old_profile_page_link)
         profile_page_link.click()
 
         sign_out_link = self.wait_for_element(BasePage.sign_out_link)


### PR DESCRIPTION
We're changing the "Your profile" link to "Your account". This change is to temporarily check for either link text on the page so that the functional tests don't fail after the change has been deployed. Once the link text change is live, we can simplify this again to only look for the new wording.