### PR TITLE
Only check for new link to the profile page

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -76,7 +76,6 @@ class NavigationLocators:
     TEMPLATES_LINK = (By.LINK_TEXT, "Templates")
     SETTINGS_LINK = (By.LINK_TEXT, "Settings")
     PROFILE_LINK = (By.LINK_TEXT, "Your account")
-    OLD_PROFILE_LINK = (By.LINK_TEXT, "Your profile")
 
 
 class TemplatePageLocators:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -126,7 +126,6 @@ class AntiStaleElementList(AntiStale):
 class BasePage:
     sign_out_link = NavigationLocators.SIGN_OUT_LINK
     profile_page_link = NavigationLocators.PROFILE_LINK
-    old_profile_page_link = NavigationLocators.OLD_PROFILE_LINK
 
     def __init__(self, driver):
         self.base_url = config["notify_admin_url"]
@@ -180,10 +179,7 @@ class BasePage:
         )
 
     def sign_out(self):
-        try:
-            profile_page_link = self.wait_for_element(BasePage.profile_page_link)
-        except (NoSuchElementException, TimeoutException):
-            profile_page_link = self.wait_for_element(BasePage.old_profile_page_link)
+        profile_page_link = self.wait_for_element(BasePage.profile_page_link)
         profile_page_link.click()
 
         sign_out_link = self.wait_for_element(BasePage.sign_out_link)


### PR DESCRIPTION
In 628020a7845616c1ffa01ff7e9dae0f21de7edcf we started to check for the profile link by looking for the text "Your profile" or "Your account". This was to avoid the tests breaking while we changed the link text. Now that the [link text has been updated](https://github.com/alphagov/notifications-admin/pull/5395) in production we can simplify the code by only checking for the new version of the text.