### PR TITLE
Bump utils to 98.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@98.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -66,7 +66,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   flask
     #   jinja2-cli
@@ -85,7 +85,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.1.0
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4b6f3f3ab8944f760987af3f3039dfeb2910ff2
     # via -r requirements.txt
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@98.0.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,8 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@98.0.1
 
-exclude = [
+extend-exclude = [
     "migrations/versions/",
-    "venv*",
     "__pycache__",
-    "node_modules",
     "cache",
     "migrations",
     "build",


### PR DESCRIPTION
Fixes https://github.com/alphagov/notifications-functional-tests/security/dependabot/13

***

 ## 98.0.1

* Moves from `setup.py` to `pyproject.toml` for package configuation
* Changes ruff config from `exclude` to `extend-exclude`

 ## 98.0.0

* Update rate multipliers for international SMS to have values for 1 April 2025 onwards. When used in notifications-api and notifications-admin this change will affect the billing of text messages the pricing shown.

 ## 97.0.5

* Fix mailto: URLs in Markdown links

 ## 97.0.4

* Fix inset text block styling

 ## 97.0.3

* Bump minimum jinja2 version to 3.1.6

 ## 97.0.2

* Fix external link redirect

 ## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

 ## 97.0.0

* for bilingual letters preview, only show barcodes on the first page (patch).
* rename `include_notify_tag` argument to `includes_first_page` (major).

 ## 96.0.0

* BREAKING CHANGE: the `gunicorn_defaults` module has been moved to `gunicorn.defaults` to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of `notifications_utils.gunicorn_defaults` should be changed to `notifications_utils.gunicorn.defaults`.
* Added `ContextRecyclingEventletWorker` custom gunicorn worker class.

 ## 95.2.0

* Implement `InsensitiveSet.__contains__`

 ## 95.1.2

* Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/95.1.1...98.0.1