### PR TITLE
upgrade setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /var/project
 
 COPY . .
 
+# TODO: remove this once base python image no longer has issues with bdist_wheel https://github.com/docker-library/official-images/issues/18808
+RUN pip install --upgrade pip setuptools
+
 RUN make bootstrap
 
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
the official base python images now ship with incompatible versions of wheel and setuptools, which can cause issues with running `python setup.py bdist_wheel`, which happens for some of our dependencies and subdependencies.

For now, a workaround is to bump setuptools to a version that doesn't have this incompatibility. We should remove this line in future once the base python image has been updated