### PR TITLE
Revert "upgrade setuptools"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ WORKDIR /var/project
 
 COPY . .
 
-# TODO: remove this once base python image no longer has issues with bdist_wheel https://github.com/docker-library/official-images/issues/18808
-RUN pip install --upgrade pip setuptools
-
 RUN make bootstrap
 
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
Reverts alphagov/notifications-functional-tests#566

The [underlying issue](https://github.com/docker-library/python/issues/1023) in the Docker image we are using has now been fixed, so we don’t have to patch it ourselves