### PR TITLE
template folder test flakyness - increase vertical size of functional tests chromedriver

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def _driver(request, download_directory):
     service = ChromeService(log_path="./logs/chrome_browser.log", service_args=["--verbose"])
 
     driver = webdriver.Chrome(service=service, options=options)
-    driver.set_window_size(1280, 720)
+    driver.set_window_size(1280, 1200)
 
     driver = EventFiringWebDriver(driver, LoggingEventListener())
     driver._listener.set_node(request.node.name)

--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -118,8 +118,6 @@ def test_edit_and_delete_email_template(driver, login_seeded_user, client_live_k
     create_email_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
     assert template_name in current_templates
 
     new_template_name = f"{template_name} v2"
@@ -133,16 +131,12 @@ def test_edit_and_delete_email_template(driver, login_seeded_user, client_live_k
 
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
     assert new_template_name in current_templates
 
     delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
     assert new_template_name not in current_templates
@@ -156,8 +150,6 @@ def test_edit_and_delete_sms_template(driver, login_seeded_user, client_live_key
     create_sms_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name in current_templates
 
@@ -171,16 +163,12 @@ def test_edit_and_delete_sms_template(driver, login_seeded_user, client_live_key
 
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
     assert new_template_name in current_templates
 
     delete_template(driver, new_template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
     assert new_template_name not in current_templates
@@ -194,15 +182,11 @@ def test_edit_and_delete_letter_template(driver, login_seeded_user, client_live_
     create_letter_template(driver, name=template_name, content=None)
     go_to_templates_page(driver)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name in current_templates
 
     delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
 
@@ -266,8 +250,6 @@ def test_send_bilingual_letter(driver, login_seeded_user, client_live_key, downl
     change_language_page.click_templates()
     delete_template(driver, template_name)
     current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "template-list-item-label")]
-    if len(current_templates) == 0:
-        current_templates = [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
     assert template_name not in current_templates
 


### PR DESCRIPTION
we've been seeing some issues with the sticky nav on template page, where we choose a template type to create but when we try to hit the continue button we scrollIntoViewIfNeeded and then when we click the button it misses. set quite a tall window in the hope that we don't need to scroll so the tests are less flaky

if we're still seeing issues after this, we may need to introduce some kind of sleep between the scrollIntoView and the click to let the sticky nav transition to being part of the scrollable DOM, possibly adjust the offset of the scroll to ensure the button is fully visible, or use js to directly trigger the click event on the button.