### PR TITLE
Update button text for join a service

### DIFF
--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -38,6 +38,7 @@ class AddServicePageLocators:
 
 
 class YourServicesPageLocators:
+    JOIN_EXISTING_SERVICE_BUTTON = (By.LINK_TEXT, "Join an existing service")
     JOIN_LIVE_SERVICE_BUTTON = (By.LINK_TEXT, "Join a live service")
     ADD_A_NEW_SERVICE_BUTTON = (By.LINK_TEXT, "Add a new service")
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -339,6 +339,7 @@ class AddServicePage(BasePage):
 
 
 class YourServicesPage(BasePage):
+    join_existing_service_button = YourServicesPageLocators.JOIN_EXISTING_SERVICE_BUTTON
     join_live_service_button = YourServicesPageLocators.JOIN_LIVE_SERVICE_BUTTON
     add_a_new_service_button = YourServicesPageLocators.ADD_A_NEW_SERVICE_BUTTON
 
@@ -346,7 +347,10 @@ class YourServicesPage(BasePage):
         return self.wait_until_url_contains(self.base_url + "/your-services")
 
     def join_live_service(self):
-        element = self.wait_for_element(YourServicesPage.join_live_service_button)
+        try:
+            element = self.wait_for_element(YourServicesPage.join_live_service_button)
+        except (NoSuchElementException, TimeoutException):
+            element = self.wait_for_element(YourServicesPage.join_existing_service_button)
         element.click()
 
     def add_new_service(self):


### PR DESCRIPTION
We're changing the text on the button for joining a service from "Join a live service" to "Join an existing service". This change allows the tests to pass with either text while the change is deployed. After, we can remove references to the old button text.