### PR TITLE
Only check for one variation of button text for join a service

### DIFF
--- a/tests/functional/preview_and_dev/test_join_live_service.py
+++ b/tests/functional/preview_and_dev/test_join_live_service.py
@@ -48,7 +48,7 @@ def _do_approver_sign_in(driver):
 def _do_request_to_join_service(driver):
     add_service_page = YourServicesPage(driver)
     add_service_page.wait_until_current()
-    add_service_page.join_live_service()
+    add_service_page.join_existing_service()
 
     add_service_page.wait_until_url_contains("/join-a-service/choose")
 
@@ -92,13 +92,13 @@ def _do_approver_rejected_request(driver):
 
 @recordtime
 @pytest.mark.xdist_group(name="join-service-request-flow")
-def test_join_live_service_rejected_flow(driver):
+def test_join_existing_service_rejected_flow(driver):
     _do_request_to_join_service(driver)
     _do_approver_rejected_request(driver)
 
 
 @recordtime
 @pytest.mark.xdist_group(name="join-service-request-flow")
-def test_join_live_service_approved_flow(driver):
+def test_join_existing_service_approved_flow(driver):
     _do_request_to_join_service(driver)
     _do_approver_approved_request(driver)

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -39,7 +39,6 @@ class AddServicePageLocators:
 
 class YourServicesPageLocators:
     JOIN_EXISTING_SERVICE_BUTTON = (By.LINK_TEXT, "Join an existing service")
-    JOIN_LIVE_SERVICE_BUTTON = (By.LINK_TEXT, "Join a live service")
     ADD_A_NEW_SERVICE_BUTTON = (By.LINK_TEXT, "Add a new service")
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -340,17 +340,13 @@ class AddServicePage(BasePage):
 
 class YourServicesPage(BasePage):
     join_existing_service_button = YourServicesPageLocators.JOIN_EXISTING_SERVICE_BUTTON
-    join_live_service_button = YourServicesPageLocators.JOIN_LIVE_SERVICE_BUTTON
     add_a_new_service_button = YourServicesPageLocators.ADD_A_NEW_SERVICE_BUTTON
 
     def wait_until_current(self):
         return self.wait_until_url_contains(self.base_url + "/your-services")
 
-    def join_live_service(self):
-        try:
-            element = self.wait_for_element(YourServicesPage.join_live_service_button)
-        except (NoSuchElementException, TimeoutException):
-            element = self.wait_for_element(YourServicesPage.join_existing_service_button)
+    def join_existing_service(self):
+        element = self.wait_for_element(YourServicesPage.join_existing_service_button)
         element.click()
 
     def add_new_service(self):


### PR DESCRIPTION
We had temporarily made a change to check for a button called either "Join a live service" or "Join an existing service" while changing the text of the button. Now that [the change has been made](https://github.com/alphagov/notifications-admin/pull/5438), we can simplify the test to only look for the new button text.