### PR TITLE
Bump utils to 99.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.1
+# This file was automatically copied from notifications-utils@99.5.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -9,7 +9,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.9.2'
+  rev: 'v0.11.4'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -40,7 +40,7 @@ execnet==2.1.1
     # via pytest-xdist
 filelock==3.12.4
     # via -r requirements_for_test.in
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-redis
     #   notifications-utils
@@ -79,13 +79,14 @@ jmespath==1.0.1
     #   botocore
 markupsafe==3.0.2
     # via
+    #   flask
     #   jinja2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.1.0
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4b6f3f3ab8944f760987af3f3039dfeb2910ff2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.txt
 ordered-set==4.1.0
     # via notifications-utils
@@ -138,7 +139,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   freezegun
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils
@@ -158,7 +159,7 @@ requests-mock==1.12.1
     # via -r requirements_for_test_common.in
 retry==0.9.2
     # via -r requirements_for_test.in
-ruff==0.9.2
+ruff==0.11.4
     # via -r requirements_for_test_common.in
 s3transfer==0.10.3
     # via boto3

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.1
+# This file was automatically copied from notifications-utils@99.5.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4
@@ -9,4 +9,4 @@ pytest-testmon==2.1.1
 requests-mock==1.12.1
 freezegun==1.5.1
 
-ruff==0.9.2  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.11.4  # Also update `.pre-commit-config.yaml` if this changes

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.1
+# This file was automatically copied from notifications-utils@99.5.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 99.5.1

* Bump minimum Flask version to 3.1.1

 ## 99.5.0

* Update economy letter transit date to 5 days

 ## 99.4.1

* Fix celery beat logging so that it will log in json

 ## 99.4.0

* Add celery logging configuration for json logging

 ## 99.3.4

* `celery.NotifyTask`: don't emit early log if called synchronously

 ## 99.3.3

* Fix bug with non-SMS templates considering international SMS limits

 ## 99.3.2

* Stops counting Crown Dependency phone numbers in CSV file as international

 ## 99.3.1

* Bump `python-json-logger` to version 3

 ## 99.3.0

* Adds `RecipientCSV.international_sms_count`
* Adds `RecipientCSV.more_international_sms_than_can_send` (initialise per `RecipientCSV(remaining_international_sms_messages=123)` to enable this check)

 ## 99.2.0

* Add s3 multipart upload lifecycle (create, upload, complete, abort)

 ## 99.1.2

* Normalise unusual dashes and spacing characters in phone numbers

 ## 99.1.1

* Bump ruff to latest version

 ## 99.1.0

* Adds support for economy mail in get_min_and_max_days_in_transit, with delivery estimated between 2 and 6 days

 ## 99.0.0

* NOTABLE CHANGE: Celery tasks emit an "early" log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument `early_log_level=logging.DEBUG` to the task decorator of your most heavily-called tasks to reduce the effect on log volume
* Annotates automatic celery task log messages with `celery_task_id`

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/98.0.1...99.5.1

***

Closes https://github.com/alphagov/notifications-functional-tests/pull/575