### PR TITLE
Revert "remove/disable unused plugins"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ markers =
     template_preview: mark a tests to run for template-preview builds.
     antivirus: mark a test to run for antivirus builds.
 
-addopts = -x -vvv -p no:pytest-testmon
+addopts = -x -vvv

--- a/requirements_for_test.in
+++ b/requirements_for_test.in
@@ -3,6 +3,7 @@
 retry==0.9.2
 selenium==4.14.0
 notifications-python-client==8.1.0
+pytest-rerunfailures==12.0
 jinja2-cli==0.8.2
 pillow==10.3.0
 pyzbar==0.1.9

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -96,6 +96,7 @@ packaging==24.2
     # via
     #   gunicorn
     #   pytest
+    #   pytest-rerunfailures
 pdf2image==1.16.3
     # via -r requirements_for_test.in
 phonenumbers==8.13.51
@@ -121,12 +122,15 @@ pytest==8.3.4
     #   -r requirements_for_test_common.in
     #   pytest-env
     #   pytest-mock
+    #   pytest-rerunfailures
     #   pytest-testmon
     #   pytest-xdist
 pytest-env==1.1.5
     # via -r requirements_for_test_common.in
 pytest-mock==3.14.0
     # via -r requirements_for_test_common.in
+pytest-rerunfailures==12.0
+    # via -r requirements_for_test.in
 pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1


### PR DESCRIPTION
Reverts alphagov/notifications-functional-tests#578

Given the number of failures on preview I'm now starting to wonder if `rerunfailures` actually was acting, albeit silently and a bit weirdly.