### PR TITLE
template-folder manipulation tests: put in same xdist_group

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -493,6 +493,7 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(driver, login_see
     assert api_integration_page.get_view_letter_link(reference) is None
 
 
+@pytest.mark.xdist_group(name="template-folders")
 def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user):
     # create new template
     template_name = f"template-for-folder-test {uuid.uuid4()}"
@@ -555,6 +556,7 @@ def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user
     assert template_name not in [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
 
+@pytest.mark.xdist_group(name="template-folders")
 def test_template_folder_permissions(driver, request, login_seeded_user):
     family_id = uuid.uuid4()
     folder_names = [


### PR DESCRIPTION
Due to what is thought to be a bug in the way we handle cache consistency, these tests interfere with each other, so for now ensure they won't run together. Once that bug is fixed, we should remove this restriction.

This is probably not the only cache-consistency-related failure we'll see, but it is a notable one.