### PR TITLE
`test_join_live_service` tests: use `create_seeded_user` fixture

### DIFF
--- a/tests/functional/preview_and_dev/test_join_live_service.py
+++ b/tests/functional/preview_and_dev/test_join_live_service.py
@@ -92,13 +92,13 @@ def _do_approver_rejected_request(driver):
 
 @recordtime
 @pytest.mark.xdist_group(name="join-service-request-flow")
-def test_join_existing_service_rejected_flow(driver):
+def test_join_existing_service_rejected_flow(driver, create_seeded_user):
     _do_request_to_join_service(driver)
     _do_approver_rejected_request(driver)
 
 
 @recordtime
 @pytest.mark.xdist_group(name="join-service-request-flow")
-def test_join_existing_service_approved_flow(driver):
+def test_join_existing_service_approved_flow(driver, create_seeded_user):
     _do_request_to_join_service(driver)
     _do_approver_approved_request(driver)


### PR DESCRIPTION
Without this, the seeded user which we use in `_do_approver_sign_in` won't be created by the `create_seeded_users` fixture, or, perhaps more importantly, won't have its `email_access_validated_at` field reset at the beginning of the tests