### PR TITLE
Revert "template-folder manipulation tests: put in same xdist_group"

### DIFF
--- a/tests/functional/preview_and_dev/test_seeded_user.py
+++ b/tests/functional/preview_and_dev/test_seeded_user.py
@@ -493,7 +493,6 @@ def test_view_precompiled_letter_message_log_virus_scan_failed(driver, login_see
     assert api_integration_page.get_view_letter_link(reference) is None
 
 
-@pytest.mark.xdist_group(name="template-folders")
 def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user):
     # create new template
     template_name = f"template-for-folder-test {uuid.uuid4()}"
@@ -556,7 +555,6 @@ def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user
     assert template_name not in [x.text for x in driver.find_elements(By.CLASS_NAME, "message-name")]
 
 
-@pytest.mark.xdist_group(name="template-folders")
 def test_template_folder_permissions(driver, request, login_seeded_user):
     family_id = uuid.uuid4()
     folder_names = [


### PR DESCRIPTION
Reverts alphagov/notifications-functional-tests#580

This will not solve the problem and it's just confusing to have this purported solution in place.

(It won't solve it because loads of tests cause the template list/template folders list cache to be repopulated, not just the explicit template-folder tests)