### PR TITLE
Move the smoke_test_csv_notification_retry_time to the global config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ environment*.sh
 docker.env
 
 screenshots
+domdumps
 
 db_fixtures/preview.sql
 db_fixtures/staging.sql

--- a/config.py
+++ b/config.py
@@ -75,6 +75,9 @@ def setup_shared_config():
             "notify_admin_url": os.environ.get("FUNCTIONAL_TESTS_ADMIN_HOST", "http://localhost:6012"),
             "name": "{} Functional Tests".format(os.environ["ENVIRONMENT"].lower()),
             "notify_service_api_key": os.environ["NOTIFY_SERVICE_API_KEY"],
+            # the smoke tests send a CSV which might get stuck behind other jobs we allow
+            # these notifications to take longer (8m rather than the normal wait of 1m15s)
+            "smoke_test_csv_notification_retry_time": 96,
         }
     )
 
@@ -136,9 +139,6 @@ def setup_functional_tests_config(unique_seeder_user_tests=None):
 def setup_smoke_tests_config():
     config.update(
         {
-            # the smoke tests send a CSV which might get stuck behind other jobs we allow
-            # these notifications to take longer (8m rather than the normal wait of 1m15s)
-            "smoke_test_csv_notification_retry_time": 96,
             "user": {
                 "email": os.environ["FUNCTIONAL_TEST_EMAIL"],
                 "password": os.environ["FUNCTIONAL_TEST_PASSWORD"],


### PR DESCRIPTION
https://trello.com/c/aFz24oI9/1157-make-smoke-tests-run-with-fixtures

What
----

Move the smoke_test_csv_notification_retry_time to the global config

Why
----

This will fix the issue we saw when trying to use the fixture config 

https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/smoke-test-file-uploads/builds/579#L6855bac1:36

