### PR TITLE
Dockerfile: Revert to Debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-bookworm
 
 # Ensure we're using Chromium v126.x
 # (Remove this if/when the performance regression in v127+ is resolved)


### PR DESCRIPTION
At some point since this image was last built, the default Debian flavour of the `python:3.11` image has changed to Trixie. Unfortunately we're pinning an old version of Chromium because newer versions cause our functional tests to hang. Until we can fix that incompatibility, we'll need to keep using Bookworm.