### PR TITLE
Attempting to fix the letter-template rename flake

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -222,6 +222,9 @@ class BasePage:
         p = pattern if isinstance(pattern, re.Pattern) else re.compile(pattern)
         return WebDriverWait(self.driver, time).until(lambda _: not p.search(self.driver.current_url))
 
+    def wait_until_contains_text(self, search_text, time=10):
+        return WebDriverWait(self.driver, time).until(lambda _: self.is_text_present_on_page(search_text))
+
     def select_checkbox_or_radio(self, element=None, value=None):
         if not element and value:
             locator = (By.CSS_SELECTOR, f"[value={value}]")
@@ -995,6 +998,9 @@ class RenameLetterTemplatePage(BasePage):
     def rename_template(self, name="Test letter template"):
         self.name_input = name
         self.click_save()
+        # Ensure rename has completed before the caller navigates away.
+        self.wait_until_url_doesnt_contain("/rename", time=20)
+        self.wait_until_contains_text(name, time=20)
 
 
 class ConfirmEditLetterTemplatePage(BasePage):


### PR DESCRIPTION
https://trello.com/c/ORCDc9Qx/1500-functional-tests-flakes

What
----

Attempting to fix the letter-template rename flow to prevent untitled…name flake.

- Adding a wait until the url no longer containers 'rename'
- Wait for the new name to appear in the page content

The functional test test_edit_and_delete_letter_template can intermittently fail after creating a letter template and returning to the templates list, with an assertion that the generated template name is missing.

Observed failure pattern:
- The template is created successfully and has a valid template UUID.
- The flow edits body content, confirms the edit, opens rename, sets the generated name, and clicks Save.
- Immediately afterwards, the helper returns and the test navigates to /templates and asserts the generated name exists.
- In flaky runs, the created template still appears in the list as 'Untitled letter template' for that UUID at assertion time.

Example failure can be viewed [here](https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1308#L69bcc8e2:78)