### PR TITLE
Attempting to fix flaky test test_creating_moving_and_deleting_template_folders

### DIFF
--- a/tests/notifications/functional_tests/test_seeded_user.py
+++ b/tests/notifications/functional_tests/test_seeded_user.py
@@ -724,6 +724,7 @@ def test_creating_moving_and_deleting_template_folders(driver, login_seeded_user
     # move template out of folder
     view_folder_page.select_template_checkbox(template_id)
     view_folder_page.move_to_root_template_folder()
+    view_folder_page.wait_until_element_is_not_present(view_folder_page.template_checkbox(template_id), time=20)
 
     # delete folder
     view_folder_page.click_manage_folder()


### PR DESCRIPTION
https://trello.com/c/ORCDc9Qx/1500-functional-tests-flakes

What
----

Example failure can be view [here](https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1302).

This attempts to fix an intermittent failure in test_creating_moving_and_deleting_template_folders where folder deletion occasionally fails at the confirm step with a timeout for element name='delete'.

Failure signature:

- The test clicks Manage, then Delete this folder, then waits for confirm_delete_folder() to find the confirm button (name='delete').
- In flaky runs, the browser is redirected back to the folder listing URL (/templates/all/folders/<id>) instead of staying on the delete-confirm page.
- The page shows banner text: 'You must empty this folder before you can delete it'.
- DOM at failure still contains the template that was just moved out, so the folder is still effectively non-empty when delete is attempted.

Scenario where this flake happens:

- Test selects the template inside the folder and submits Move to root.
- The move request is accepted, but the folder page update is not yet fully reflected in DOM/state.
- Test immediately navigates to manage/delete flow.
- Backend/UI still evaluates folder as non-empty and routes back to folder page with error banner.
- confirm_delete_folder() then times out because delete-confirm button is not present on that page.

What this change does:

- After move_to_root_template_folder(), explicitly wait until the moved template checkbox is no longer present in the folder list.
- Only then continue to manage/delete steps.