### PR TITLE
Attempting to fix folder rename assertion by waiting for updated heading

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1600,6 +1600,10 @@ class ViewFolderPage(ShowTemplatesPage):
         link.click()
 
     def assert_name_equals(self, expected_name):
+        WebDriverWait(self.driver, 10).until(
+            EC.text_to_be_present_in_element(self.template_name, expected_name),
+            f"Folder name did not update to '{expected_name}' on URL {self.current_url}",
+        )
         h1 = self.wait_for_element(self.template_name)
         assert expected_name in h1.text
 


### PR DESCRIPTION
https://trello.com/c/ORCDc9Qx/1500-functional-tests-flakes

What
----

Example failure can be found [here](https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1280#L69bc6452:137)

Attempting to fix folder rename assertion by waiting for updated heading

This commit addresses a flake in test_creating_moving_and_deleting_template_folders where the test can assert the folder name too soon after submitting the Manage folder form.

Problem:

- After clicking Save on /templates/folders/<id>/manage, the browser is redirected back to /templates/all/folders/<id>.
- The URL transition can complete before the heading text has updated to the new folder name.
- assert_name_equals then reads h1 immediately and intermittently fails.

Fix:

- In ViewFolderPage.assert_name_equals, add an explicit wait for expected heading text using EC.text_to_be_present_in_element.
- Keep the existing final assertion so the helper still fails clearly if text never appears.