### PR TITLE
Add test sending a file one off via document download via UI

### DIFF
--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -1,6 +1,20 @@
 import uuid
 
-from tests.pages import ManageFilesForEmailTemplatePage, ShowTemplatesPage, ViewEmailTemplatePage
+import pytest
+
+from config import config
+from tests.pages import (
+    ChangeLinkTextForEmailFilePage,
+    DocumentDownloadLandingPage,
+    ManageEmailTemplateFilePage,
+    ManageFilesForEmailTemplatePage,
+    SendEmailPreviewPage,
+    SendOneRecipientPage,
+    SendSetSenderPage,
+    SentEmailMessagePage,
+    ShowTemplatesPage,
+    ViewEmailTemplatePage,
+)
 from tests.test_utils import (
     create_an_email_template_and_attach_a_file,
     delete_file_from_email_template_via_manage_files_page,
@@ -9,6 +23,7 @@ from tests.test_utils import (
 
 
 @recordtime
+@pytest.mark.xdist_group(name="send-files-via-ui-flow")
 def test_attaching_files_to_emails_and_also_deleting_them_via_ui(driver, login_seeded_user):
     # Test Creating an email template and attach a file to it
     template_name = f"Functional Tests - upload/delete file to email template - {uuid.uuid4()}"
@@ -33,6 +48,89 @@ def test_attaching_files_to_emails_and_also_deleting_them_via_ui(driver, login_s
     assert view_email_template_page.get_file_added_count_text() == "No files added"
 
     # delete template
+    assert view_email_template_page.get_h1_text() == template_name
+    view_email_template_page.click_delete_template_link()
+    view_email_template_page.click_template_deletion_confirmation_button()
+
+    # confirm template has been deleted
+    templates_page = ShowTemplatesPage(driver)
+    assert templates_page.get_h1_text() == "Templates"
+    assert template_name not in templates_page.get_all_listed_templates()
+
+
+@recordtime
+@pytest.mark.xdist_group(name="send-files-via-ui-flow")
+def test_send_one_off_email_with_file_via_ui(driver, login_seeded_user):
+    # Create an email template
+    template_name = f"Functional Tests - send one off email with file via ui - {uuid.uuid4()}"
+    content = "Testing sending a one off email notification. with an email file. Test file below:"
+    file_name = "attachment.pdf"
+    create_an_email_template_and_attach_a_file(driver, file_name, template_name, content)
+
+    # Confirm file has been attached to template on the Preview email template page
+    view_email_template_page = ViewEmailTemplatePage(driver)
+    assert view_email_template_page.get_h1_text() == template_name
+    assert view_email_template_page.get_file_added_count_text() == "1 file added"
+
+    # go to the individual file management page and change the link text
+    view_email_template_page.click_manage_files_button()
+    manage_files_page = ManageFilesForEmailTemplatePage(driver)
+    assert manage_files_page.get_h1_text() == "Manage files"
+    link_text_label = "Link text"
+    link_text = "file_download_link"
+    manage_files_page.click_manage_link(file_name)
+    manage_file_page = ManageEmailTemplateFilePage(driver)
+    assert manage_file_page.get_h1_text() == file_name
+    manage_file_page.click_change_file_setting(link_text_label)
+    change_link_text_page = ChangeLinkTextForEmailFilePage(driver)
+    assert change_link_text_page.get_h1_text() == "Add link text"
+    change_link_text_page.fill_in_link_text(link_text)
+    change_link_text_page.click_continue_button()
+
+    manage_file_page.click_back_link()
+    assert manage_file_page.get_h1_text() == "Manage files"
+    manage_file_page.click_back_link()
+
+    # send the email
+    assert view_email_template_page.get_h1_text() == template_name
+    assert link_text in view_email_template_page.get_email_message_body_content()
+    view_email_template_page.click_send()
+
+    set_sender_page = SendSetSenderPage(driver)
+    set_sender_page.wait_until_current()
+    assert set_sender_page.get_h1_text() == "Where should replies come back to?"
+    set_sender_page.click_continue_button()
+
+    send_to_one_recipient_page = SendOneRecipientPage(driver)
+    assert send_to_one_recipient_page.get_h1_text() == f"Send ‘{template_name}’"
+    send_to_one_recipient_page.send_to_myself("email")
+
+    preview_send_one_recepient_page = SendEmailPreviewPage(driver)
+    assert preview_send_one_recepient_page.get_h1_text() == f"Preview of ‘{template_name}’"
+    preview_send_one_recepient_page.click_send_button()
+
+    # confirm that the email is being delivered
+    send_email_confirmation_page = SentEmailMessagePage(driver)
+    assert send_email_confirmation_page.get_h1_text() == "Email"
+    assert "Delivering" in send_email_confirmation_page.get_notification_status()
+
+    # Confirm that the file download link sent to the recipient works
+    # There are smoke tests and other tests covering the process of a recipient downloading
+    # a document, so the whole journey will not be covered here
+    send_email_confirmation_page.click_file_download_link(link_text)
+    you_have_a_file_to_download_page = DocumentDownloadLandingPage(driver)
+    assert you_have_a_file_to_download_page.get_h1_text() == "You have a file to download"
+    you_have_a_file_to_download_page.go_to_download_page()
+
+    # Go to service templates page and select the template
+    base_url = config["notify_admin_url"]
+    service_template_page_url = f"{base_url}/services/{config['service']['id']}/templates"
+    you_have_a_file_to_download_page.get(service_template_page_url)
+    templates_pages = ShowTemplatesPage(driver)
+    assert templates_pages.get_h1_text() == "Templates"
+    templates_pages.click_template_by_link_text(template_name)
+
+    # delete the template
     assert view_email_template_page.get_h1_text() == template_name
     view_email_template_page.click_delete_template_link()
     view_email_template_page.click_template_deletion_confirmation_button()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -133,6 +133,7 @@ class BasePage:
     sign_out_link = NavigationLocators.SIGN_OUT_LINK
     profile_page_link = NavigationLocators.PROFILE_LINK
     h1_text = (By.CSS_SELECTOR, "h1")
+    templates_link = NavigationLocators.TEMPLATES_LINK
 
     def __init__(self, driver):
         self.base_url = config["notify_admin_url"]
@@ -881,6 +882,7 @@ class ViewEmailTemplatePage(ViewTemplatePage):
     page_banner_text = ViewEmailTemplatePageLocators.PAGE_BANNER_TEXT
     delete_template_link = ViewEmailTemplatePageLocators.DELETE_TEMPLATE_LINK
     template_deletion_confirmation_button = ViewEmailTemplatePageLocators.TEMPLATE_DELETION_CONFIRMATION_BUTTON
+    email_message_body_content = (By.XPATH, "//div[contains(@class, 'email-message-body')]")
 
     def click_attach_files_button(self):
         element = self.wait_for_element(ViewEmailTemplatePage.attach_files_button)
@@ -906,6 +908,10 @@ class ViewEmailTemplatePage(ViewTemplatePage):
         element = self.wait_for_element(ViewEmailTemplatePage.template_deletion_confirmation_button)
         element.click()
 
+    def get_email_message_body_content(self):
+        element = self.wait_for_element(ViewEmailTemplatePage.email_message_body_content)
+        return element.text.strip()
+
 
 class AddFileToEmailTemplatePage(BasePage):
     choose_file_button = AddFileToEmailTemplatePageLocators.CHOOSE_FILE_BUTTON
@@ -930,6 +936,10 @@ class ManageEmailTemplateFilePage(BasePage):
     file_link = ManageEmailTemplateFilePageLocators.REMOVE_FILE_LINK
     add_to_template = ManageEmailTemplateFilePageLocators.ADD_TO_TEMPLATE_BUTTON
     remove_file_dialog_button = ManageEmailTemplateFilePageLocators.REMOVE_FILE_DIALOG_BUTTON
+    change_link_text_change = (
+        By.XPATH,
+        "//div[contains(@class, 'govuk-summary-list__row')][dt[contains(., 'Link text')]]//a[contains(., 'Change')]",
+    )
 
     def click_remove_file_link(self):
         element = self.wait_for_element(ManageEmailTemplateFilePage.file_link)
@@ -942,6 +952,26 @@ class ManageEmailTemplateFilePage(BasePage):
     def click_remove_file_dialog_button(self):
         element = self.wait_for_element(ManageEmailTemplateFilePage.remove_file_dialog_button)
         element.click()
+
+    def click_change_file_setting(self, label):
+        xpath = (
+            f"//div[contains(@class, 'govuk-summary-list__row')][dt[contains(., '{label}')]]//a[contains(., 'Change')]"
+        )
+        element = self.wait_for_element((By.XPATH, xpath))
+        element.click()
+
+
+class ChangeLinkTextForEmailFilePage(BasePage):
+    link_text_input = (By.CSS_SELECTOR, "input[name='link_text'][id='link_text']")
+    continue_button = (By.CSS_SELECTOR, "button[type='submit']")
+
+    def click_continue_button(self):
+        element = self.wait_for_element(ChangeLinkTextForEmailFilePage.continue_button)
+        element.click()
+
+    def fill_in_link_text(self, value):
+        element = self.wait_for_element(ChangeLinkTextForEmailFilePage.link_text_input)
+        element.send_keys(value)
 
 
 class ManageFilesForEmailTemplatePage(BasePage):
@@ -1454,6 +1484,7 @@ class SendSetSenderPage(BasePage):
         By.XPATH,
         "//label[normalize-space(text())='func tests']/preceding-sibling::input[@type='radio']",
     )
+    continue_button = (By.CSS_SELECTOR, "button[type='submit']")
 
     def wait_until_current(self, time=10):
         return self.wait_until_url_matches(r"/set-sender(\?.*)?$", time=time)
@@ -1468,6 +1499,10 @@ class SendSetSenderPage(BasePage):
     def choose_alternative_sms_sender(self):
         radio = self.wait_for_design_system_checkbox_or_radio(self.alternative_sender_sms_radio)
         radio.click()
+
+    def click_continue_button(self):
+        element = self.wait_for_element(SendSetSenderPage.continue_button)
+        element.click()
 
 
 class SendOneRecipientPage(BasePage):
@@ -1507,6 +1542,36 @@ class SendOneRecipientPage(BasePage):
 
     def click_use_emergency_list(self):
         element = self.wait_for_element(SingleRecipientLocators.USE_EMERGENCY_LIST)
+        element.click()
+
+
+class SendEmailPreviewPage(BasePage):
+    """
+    The send file via ui journey slightly differs from the usual one-off email journey
+    hence the need for this separate class
+    """
+
+    send_button = (By.CSS_SELECTOR, "button[type='submit'")
+
+    def click_send_button(self):
+        element = self.wait_for_element(SendEmailPreviewPage.send_button)
+        element.click()
+
+
+class SentEmailMessagePage(BasePage):
+    """
+    The send file via ui journey slightly differs from the usual one-off email journey
+    hence the need for this separate class
+    """
+
+    notification_status = (By.XPATH, "//p[contains(@class, 'notification-status')]")
+
+    def get_notification_status(self):
+        element = self.wait_for_element(SentEmailMessagePage.notification_status)
+        return element.get_attribute("textContent").strip()
+
+    def click_file_download_link(self, link_text):
+        element = self.wait_for_element((By.XPATH, f"//a[contains(., '{link_text}')]"))
         element.click()
 
 


### PR DESCRIPTION
This PR adds a test covering sending a file one off via document download via UI.
It is dependant on this [PR](https://github.com/alphagov/notifications-functional-tests/pull/636)