### PR TITLE
Add test document download via UI file management pages

### DIFF
--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -5,7 +5,9 @@ import pytest
 from config import config
 from tests.pages import (
     ChangeLinkTextForEmailFilePage,
+    ChangeRentionPeriodForEmailFilePage,
     DocumentDownloadLandingPage,
+    EmailConfirmationSettingForEmailFilePage,
     ManageEmailTemplateFilePage,
     ManageFilesForEmailTemplatePage,
     SendEmailPreviewPage,
@@ -131,6 +133,88 @@ def test_send_one_off_email_with_file_via_ui(driver, login_seeded_user):
     templates_pages.click_template_by_link_text(template_name)
 
     # delete the template
+    assert view_email_template_page.get_h1_text() == template_name
+    view_email_template_page.click_delete_template_link()
+    view_email_template_page.click_template_deletion_confirmation_button()
+
+    # confirm template has been deleted
+    templates_page = ShowTemplatesPage(driver)
+    assert templates_page.get_h1_text() == "Templates"
+    assert template_name not in templates_page.get_all_listed_templates()
+
+
+@recordtime
+@pytest.mark.xdist_group(name="send-files-via-ui-flow")
+def test_email_template_file_management_settings(driver, login_seeded_user):
+    # Test Creating an email template and attach a file to it
+    template_name = f"Functional Tests - test email file management settings- {uuid.uuid4()}"
+    content = "Hi ((name)), download this file:"
+    file_name = "attachment.pdf"
+    create_an_email_template_and_attach_a_file(driver, file_name, template_name, content)
+
+    # Confirm file has been attached to template on the Preview email template page
+    view_email_template_page = ViewEmailTemplatePage(driver)
+    assert view_email_template_page.get_h1_text() == template_name
+    assert view_email_template_page.get_file_added_count_text() == "1 file added"
+
+    # Go to file management page
+    view_email_template_page.click_manage_files_button()
+    manage_files_page = ManageFilesForEmailTemplatePage(driver)
+    assert manage_files_page.get_h1_text() == "Manage files"
+    manage_files_page.click_manage_link(file_name)
+    manage_a_file_page = ManageEmailTemplateFilePage(driver)
+    assert manage_a_file_page.get_h1_text() == file_name
+
+    # Change link text
+    link_text_label = "Link text"
+    original_link_text = manage_a_file_page.get_file_setting_value(link_text_label)
+    assert original_link_text == "Not set"
+    manage_a_file_page.click_change_file_setting(link_text_label)
+    change_link_text_page = ChangeLinkTextForEmailFilePage(driver)
+    assert change_link_text_page.get_h1_text() == "Add link text"
+    new_link_text = "file_download_link"
+    change_link_text_page.fill_in_link_text(new_link_text)
+    change_link_text_page.click_continue_button()
+
+    # confirm link text change
+    assert manage_a_file_page.get_file_setting_value(link_text_label) == new_link_text
+
+    # Change retention period
+    retention_period_label = "Available for"
+    original_retention_period_text = manage_a_file_page.get_file_setting_value(retention_period_label)
+    assert original_retention_period_text == "26 weeks after sending\n        (about 6 months)"
+    manage_a_file_page.click_change_file_setting(retention_period_label)
+    assert change_link_text_page.get_h1_text() == "How long the file is available"
+    change_retention_period = ChangeRentionPeriodForEmailFilePage(driver)
+    new_retention_period = "50"
+    change_retention_period.fill_in_retention_period(new_retention_period)
+    change_retention_period.click_continue_button()
+
+    # confirm retention period change
+    assert (
+        manage_a_file_page.get_file_setting_value(retention_period_label)
+        == f"{new_retention_period} weeks after sending\n        (about 11 months)"
+    )
+    assert manage_a_file_page.get_h1_text() == file_name
+
+    # Change email confirmation
+    email_confirmation_label = "Ask recipient for email address"
+    confirmation_label_choice = manage_a_file_page.get_file_setting_value(email_confirmation_label)
+    assert confirmation_label_choice == "Yes"
+    manage_a_file_page.click_change_file_setting(email_confirmation_label)
+    email_confirmation_page = EmailConfirmationSettingForEmailFilePage(driver)
+    assert email_confirmation_page.get_h1_text() == "Ask recipient for their email address"
+    new_confirmation_label_choice = "No"
+    email_confirmation_page.select_email_confirmation_option(new_confirmation_label_choice)
+    email_confirmation_page.click_continue_button()
+
+    # confirm email confirmation option change
+    assert manage_a_file_page.get_h1_text() == file_name
+    assert manage_a_file_page.get_file_setting_value(email_confirmation_label) == new_confirmation_label_choice
+
+    # delete template which would also delete file
+    manage_a_file_page.click_back_link()
+    manage_files_page.click_back_link()
     assert view_email_template_page.get_h1_text() == template_name
     view_email_template_page.click_delete_template_link()
     view_email_template_page.click_template_deletion_confirmation_button()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -953,12 +953,54 @@ class ManageEmailTemplateFilePage(BasePage):
         element = self.wait_for_element(ManageEmailTemplateFilePage.remove_file_dialog_button)
         element.click()
 
+    def get_file_setting_value(self, label):
+        xpath = f"//div[contains(@class, 'govuk-summary-list__row')][dt[contains(., '{label}')]]//dd[contains(@class, 'govuk-summary-list__value')]"  # noqa: E501
+        element = self.wait_for_element((By.XPATH, xpath))
+        return element.get_attribute("textContent").strip()
+
     def click_change_file_setting(self, label):
         xpath = (
             f"//div[contains(@class, 'govuk-summary-list__row')][dt[contains(., '{label}')]]//a[contains(., 'Change')]"
         )
         element = self.wait_for_element((By.XPATH, xpath))
         element.click()
+
+
+class ManageFilesForEmailTemplatePage(BasePage):
+    def click_manage_link(self, file_name):
+        # The current implementation of the manage link is such that there could be multiple links
+        # with the file name displayed in a hidden span tag being the only differentiator
+        # This method needs to be dynamic to filter on the file nane.
+        element = self.wait_for_element((By.XPATH, f"//a[contains(text(), 'Manage')][contains(., {file_name})]"))
+
+        element.click()
+
+
+class EmailConfirmationSettingForEmailFilePage(BasePage):
+    continue_button = (By.CSS_SELECTOR, "button[type='submit']")
+
+    def click_continue_button(self):
+        element = self.wait_for_element(ChangeRentionPeriodForEmailFilePage.continue_button)
+        element.click()
+
+    def select_email_confirmation_option(self, value):
+        xpath = f"//div[fieldset[legend[contains(., 'confirm their email address')]]]//label[contains(., '{value}')]"
+        element = self.wait_for_element((By.XPATH, xpath))
+        element.click()
+
+
+class ChangeRentionPeriodForEmailFilePage(BasePage):
+    retention_period_input = (By.CSS_SELECTOR, "input[name='retention_period'][id='retention_period']")
+    continue_button = (By.CSS_SELECTOR, "button[type='submit']")
+
+    def click_continue_button(self):
+        element = self.wait_for_element(ChangeRentionPeriodForEmailFilePage.continue_button)
+        element.click()
+
+    def fill_in_retention_period(self, value):
+        element = self.wait_for_element(ChangeRentionPeriodForEmailFilePage.retention_period_input)
+        element.clear()
+        element.send_keys(value)
 
 
 class ChangeLinkTextForEmailFilePage(BasePage):
@@ -971,16 +1013,8 @@ class ChangeLinkTextForEmailFilePage(BasePage):
 
     def fill_in_link_text(self, value):
         element = self.wait_for_element(ChangeLinkTextForEmailFilePage.link_text_input)
+        element.clear()
         element.send_keys(value)
-
-
-class ManageFilesForEmailTemplatePage(BasePage):
-    def click_manage_link(self, file_name):
-        # The current implementation of the manage link is such that there could be multiple links
-        # with the file name displayed in a hidden span tag being the only differentiator
-        # This method needs to be dynamic to filter on the file nane.
-        element = self.wait_for_element((By.XPATH, f"//a[contains(text(), 'Manage')][contains(., '{file_name}')]"))
-        element.click()
 
 
 class EditLetterTemplatePage(BasePage):


### PR DESCRIPTION
This PR adds a test to cover the user journey for changing file settings for files attached to email templates.
Presently the available settings are:

- link text
- file retention period
- email ocnfirmation