### PR TITLE
Add test_send_file_via_ui_preview_pages

### DIFF
--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -3,6 +3,9 @@ import uuid
 import pytest
 
 from config import config
+from pypdf import PdfReader
+
+from config import config, generate_unique_email
 from tests.pages import (
     ChangeLinkTextForEmailFilePage,
     ChangeRentionPeriodForEmailFilePage,
@@ -14,12 +17,16 @@ from tests.pages import (
     SendOneRecipientPage,
     SendSetSenderPage,
     SentEmailMessagePage,
+    PreviewConfirmYourEmailAddressPage,
+    PreviewDownloadYourFilePage,
+    PreviewYouHaveAFileToDownloadPage,
     ShowTemplatesPage,
     ViewEmailTemplatePage,
 )
 from tests.test_utils import (
     create_an_email_template_and_attach_a_file,
     delete_file_from_email_template_via_manage_files_page,
+    get_downloaded_document,
     recordtime,
 )
 
@@ -221,5 +228,90 @@ def test_email_template_file_management_settings(driver, login_seeded_user):
 
     # confirm template has been deleted
     templates_page = ShowTemplatesPage(driver)
+    assert templates_page.get_h1_text() == "Templates"
+    assert template_name not in templates_page.get_all_listed_templates()
+
+
+@recordtime
+@pytest.mark.xdist_group(name="send-files-via-ui-flow")
+def test_send_file_via_ui_preview_pages(driver, login_seeded_user, download_directory):
+    # Test Creating an email template and attach a file to it
+    template_name = f"Functional Tests - test email template file preview pages - {uuid.uuid4()}"
+    content = "Hi ((name)), download this file:"
+    file_name = "attachment.pdf"
+    create_an_email_template_and_attach_a_file(driver, file_name, template_name, content)
+
+    # go to the individual file management page and change the link text
+    view_email_template_page = ViewEmailTemplatePage(driver)
+    view_email_template_page.click_manage_files_button()
+    manage_files_page = ManageFilesForEmailTemplatePage(driver)
+    link_text_label = "Link text"
+    new_link_text = "file_download_link"
+    manage_files_page.click_manage_link(file_name)
+    manage_a_file_page = ManageEmailTemplateFilePage(driver)
+    manage_a_file_page.click_change_file_setting(link_text_label)
+    change_link_text_page = ChangeLinkTextForEmailFilePage(driver)
+    change_link_text_page.fill_in_link_text(new_link_text)
+    change_link_text_page.click_continue_button()
+
+    # go to template page and click on file link
+    manage_a_file_page.click_back_link()
+    manage_files_page.click_back_link()
+    assert view_email_template_page.get_h1_text() == template_name
+    view_email_template_page.click_file_link_text(new_link_text)
+
+    # Test you have a file to download preview page
+    preview_you_have_a_file_page = PreviewYouHaveAFileToDownloadPage(driver)
+    banner_title = "Preview"
+    banner_heading = "This is a preview of the page your recipients will see"
+    assert preview_you_have_a_file_page.get_banner_title() == banner_title
+    assert preview_you_have_a_file_page.get_banner_heading() == banner_heading
+    assert preview_you_have_a_file_page.get_h1_text() == "You have a file to download"
+    preview_you_have_a_file_page.click_continue_button()
+
+    # Test confirm your email address preview page
+    preview_confirm_email_page = PreviewConfirmYourEmailAddressPage(driver)
+    banner_title = "Preview"
+    banner_heading = "This is a preview of the page your recipients will see"
+    assert preview_confirm_email_page.get_banner_title() == banner_title
+    assert preview_confirm_email_page.get_banner_heading() == banner_heading
+    assert preview_confirm_email_page.get_h1_text() == "Confirm your email address"
+    # We need the seeded user email address generated for the test run
+    seeded_user_email = generate_unique_email(
+        config["service"]["seeded_user"]["email"], "test_send_file_via_ui_preview_pages"
+    )
+    preview_confirm_email_page.fill_in_email_address(seeded_user_email)
+    preview_confirm_email_page.click_continue_button()
+
+    # Test the download your file preview page
+    preview_download_file_page = PreviewDownloadYourFilePage(driver)
+    banner_title = "Preview"
+    banner_heading = "This is a preview of the page your recipients will see"
+    assert preview_download_file_page.get_banner_title() == banner_title
+    assert preview_download_file_page.get_banner_heading() == banner_heading
+    assert preview_download_file_page.get_h1_text() == "Download your file"
+
+    # Download the file and confirm the file has been downloaded
+    preview_download_file_page.click_download_link()
+
+    document_path = get_downloaded_document(download_directory, file_name)
+    pdf_reader = PdfReader(document_path)
+    pdf_text = pdf_reader.pages[0].extract_text()
+    result_text = " ".join(pdf_text).split()
+    expected_text = " ".join("This is an attachment").split()
+    assert result_text == expected_text
+
+    # delete the template which will also archive the file attached
+    service_templates_url = f"{config['notify_admin_url']}/services/{config['service']['id']}/templates"
+    preview_download_file_page.get(service_templates_url)
+    assert view_email_template_page.get_h1_text() == "Templates"
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
+    assert view_email_template_page.get_h1_text() == template_name
+    view_email_template_page.click_delete_template_link()
+    view_email_template_page.click_template_deletion_confirmation_button()
+
+    # confirm template has been deleted
+
     assert templates_page.get_h1_text() == "Templates"
     assert template_name not in templates_page.get_all_listed_templates()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -911,6 +911,9 @@ class ViewEmailTemplatePage(ViewTemplatePage):
     def get_email_message_body_content(self):
         element = self.wait_for_element(ViewEmailTemplatePage.email_message_body_content)
         return element.text.strip()
+    def click_file_link_text(self, link_text):
+        element = self.wait_for_element((By.XPATH, f"//a[contains(text(), '{link_text}')]"))
+        element.click()
 
 
 class AddFileToEmailTemplatePage(BasePage):
@@ -954,7 +957,11 @@ class ManageEmailTemplateFilePage(BasePage):
         element.click()
 
     def get_file_setting_value(self, label):
-        xpath = f"//div[contains(@class, 'govuk-summary-list__row')][dt[contains(., '{label}')]]//dd[contains(@class, 'govuk-summary-list__value')]"  # noqa: E501
+        xpath = (
+            f"//div[contains(@class, 'govuk-summary-list__row')]"
+            f"[dt[contains(., '{label}')]]"
+            f"//dd[contains(@class, 'govuk-summary-list__value')]"
+        )
         element = self.wait_for_element((By.XPATH, xpath))
         return element.get_attribute("textContent").strip()
 
@@ -980,7 +987,7 @@ class EmailConfirmationSettingForEmailFilePage(BasePage):
     continue_button = (By.CSS_SELECTOR, "button[type='submit']")
 
     def click_continue_button(self):
-        element = self.wait_for_element(ChangeRentionPeriodForEmailFilePage.continue_button)
+        element = self.wait_for_element(EmailConfirmationSettingForEmailFilePage.continue_button)
         element.click()
 
     def select_email_confirmation_option(self, value):
@@ -1893,3 +1900,54 @@ class UnsubscribeRequestReportPage(BasePage):
     def click_update_button(self):
         element = self.wait_for_element(UnsubscribeRequestReportPage.update_report_button)
         element.click()
+
+
+class PreviewSendFileViaEmailDownloadPages(BasePage):
+    BANNER_TITLE = (By.CSS_SELECTOR, "#govuk-notification-banner-title")
+    BANNER_HEADER = (By.CSS_SELECTOR, "p[class='govuk-notification-banner__heading']")
+
+    def get_banner_title(self):
+        element = self.wait_for_element(PreviewSendFileViaEmailDownloadPages.BANNER_TITLE)
+        return element.get_attribute("textContent").strip()
+
+    def get_banner_heading(self):
+        element = self.wait_for_element(PreviewSendFileViaEmailDownloadPages.BANNER_HEADER)
+        return element.get_attribute("textContent").strip()
+
+
+class PreviewYouHaveAFileToDownloadPage(PreviewSendFileViaEmailDownloadPages):
+    continue_button = (By.CSS_SELECTOR, "a[role='button'][class='govuk-button']")
+
+    def click_continue_button(self):
+        element = self.wait_for_element(PreviewYouHaveAFileToDownloadPage.continue_button)
+        element.click()
+
+
+class PreviewConfirmYourEmailAddressPage(PreviewSendFileViaEmailDownloadPages):
+    email_input = (By.ID, "email_address")
+    continue_button = (By.CSS_SELECTOR, "button[type='submit']")
+
+    def click_continue_button(self):
+        element = self.wait_for_element(PreviewConfirmYourEmailAddressPage.continue_button)
+        element.click()
+
+    def fill_in_email_address(self, value):
+        element = self.wait_for_element(PreviewConfirmYourEmailAddressPage.email_input)
+        element.send_keys(value)
+
+    def get_errors(self):
+        error_message = (By.CSS_SELECTOR, "#email_address-error")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
+
+
+class PreviewDownloadYourFilePage(PreviewSendFileViaEmailDownloadPages):
+    download_link = (By.PARTIAL_LINK_TEXT, "Download this")
+
+    def click_download_link(self):
+        element = self.wait_for_element(PreviewDownloadYourFilePage.download_link)
+        element.click()
+
+    def get_download_link(self):
+        element = self.wait_for_element(PreviewDownloadYourFilePage.download_link)
+        return element.get_attribute("href")


### PR DESCRIPTION
This PR adds a test to cover the `send file via ui ` preview pages which are :
i. the landing page
ii. email confirmation page
iii.download page