### PR TITLE
fix: inbound_sms race condition

### DIFF
--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -1,10 +1,10 @@
 import uuid
 
-from tests.pages import ViewEmailTemplatePage, ManageFilesForEmailTemplatePage, ShowTemplatesPage
+from tests.pages import ManageFilesForEmailTemplatePage, ShowTemplatesPage, ViewEmailTemplatePage
 from tests.test_utils import (
-    recordtime,
-    delete_file_from_email_template_via_manage_files_page, delete_template,
     create_an_email_template_and_attach_a_file,
+    delete_file_from_email_template_via_manage_files_page,
+    recordtime,
 )
 
 

--- a/tests/notifications/functional_tests/test_inbound_sms.py
+++ b/tests/notifications/functional_tests/test_inbound_sms.py
@@ -10,6 +10,7 @@ Test:
     look at inbox page - assert that the new message is in the conversation
 """
 
+import uuid
 from datetime import UTC, datetime
 from urllib.parse import quote_plus
 
@@ -21,10 +22,10 @@ from config import config
 from tests.pages import ConversationPage, DashboardPage, InboxPage
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def inbound_sms():
     # the message has the func test user's name in it - which has a unique uuid
-    message = "Inbound message from {}".format(config["user"]["name"])
+    message = f"Inbound message from {uuid.uuid4()}"
 
     # hand-craft a request to receive messages API.
     mmg_inbound_body = {

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -34,6 +34,7 @@ from tests.pages.element import (
     TemplateContentElement,
 )
 from tests.pages.locators import (
+    AddFileToEmailTemplatePageLocators,
     AddServicePageLocators,
     ApiIntegrationPageLocators,
     ChangeNameLocators,
@@ -44,6 +45,7 @@ from tests.pages.locators import (
     JobPageLocators,
     LetterPreviewPageLocators,
     MainPageLocators,
+    ManageEmailTemplateFilePageLocators,
     ManageLetterAttachPageLocators,
     NavigationLocators,
     RenameTemplatePageLocators,
@@ -59,10 +61,10 @@ from tests.pages.locators import (
     TeamMembersPageLocators,
     TemplatePageLocators,
     VerifyPageLocators,
+    ViewEmailTemplatePageLocators,
     ViewLetterTemplatePageLocators,
     ViewTemplatePageLocators,
-    YourServicesPageLocators, ViewEmailTemplatePageLocators, AddFileToEmailTemplatePageLocators,
-    ManageEmailTemplateFilePageLocators, ManageFilesForEmailTemplatePageLocators,
+    YourServicesPageLocators,
 )
 
 
@@ -788,9 +790,7 @@ class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
 
     def get_all_listed_templates(self):
         locator = (By.CLASS_NAME, "template-list-item-label")
-        WebDriverWait(self.driver, 10).until(
-            EC.presence_of_element_located(locator)
-        )
+        WebDriverWait(self.driver, 10).until(EC.presence_of_element_located(locator))
 
         elements = self.driver.find_elements(*locator)
 
@@ -945,7 +945,6 @@ class ManageEmailTemplateFilePage(BasePage):
 
 
 class ManageFilesForEmailTemplatePage(BasePage):
-
     def click_manage_link(self, file_name):
         # The current implementation of the manage link is such that there could be multiple links
         # with the file name displayed in a hidden span tag being the only differentiator

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,8 +42,12 @@ from tests.pages import (
     ViewTemplatePage,
     YourServicesPage,
 )
-from tests.pages.pages import RenameLetterTemplatePage, ViewEmailTemplatePage, AddFileToEmailTemplatePage, \
-    ManageEmailTemplateFilePage
+from tests.pages.pages import (
+    AddFileToEmailTemplatePage,
+    ManageEmailTemplateFilePage,
+    RenameLetterTemplatePage,
+    ViewEmailTemplatePage,
+)
 
 logging.basicConfig(filename=f"./logs/test_run_{datetime.now(UTC)}.log", level=logging.INFO)
 


### PR DESCRIPTION
we have found instances of tests failing where inbound sms have been created twice when a test expects them to only be created once. We are unsure of the true root cause, but think it may be either to do with xdist workers causing a race condition or because the module scope of the fixture may be leakier than we think (multiple functions in what we expect to be the same module may instantiate this multiple times).

by making the fixture function scoped with a unique message per fixture this should avoid most of the race conditions we've observed (so long as the test checks the uniqueness of the message).