### PR TITLE
Add test_send_email_notification_with_an_email_file_via_csv

### DIFF
--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -1,9 +1,8 @@
 import uuid
 
 import pytest
-
-from config import config
 from pypdf import PdfReader
+from selenium.webdriver.common.by import By
 
 from config import config, generate_unique_email
 from tests.pages import (
@@ -11,24 +10,28 @@ from tests.pages import (
     ChangeRentionPeriodForEmailFilePage,
     DocumentDownloadLandingPage,
     EmailConfirmationSettingForEmailFilePage,
+    JobPage,
     ManageEmailTemplateFilePage,
     ManageFilesForEmailTemplatePage,
-    SendEmailPreviewPage,
-    SendOneRecipientPage,
-    SendSetSenderPage,
-    SentEmailMessagePage,
     PreviewConfirmYourEmailAddressPage,
     PreviewDownloadYourFilePage,
     PreviewYouHaveAFileToDownloadPage,
+    SendEmailPreviewPage,
+    SendFilesViaUiUploadCsvPage,
+    SendOneRecipientPage,
+    SendSetSenderPage,
+    SendViaCsvPage,
+    SendViaCsvPreviewPage,
+    SentEmailMessagePage,
     ShowTemplatesPage,
-    ViewEmailTemplatePage, SendViaCsvPage, SendViaCsvPreviewPage, JobPage,
+    ViewEmailTemplatePage,
 )
-from tests.postman import send_notification_via_csv
 from tests.test_utils import (
     create_an_email_template_and_attach_a_file,
+    create_temp_csv,
     delete_file_from_email_template_via_manage_files_page,
     get_downloaded_document,
-    recordtime, create_temp_csv,
+    recordtime,
 )
 
 
@@ -137,6 +140,7 @@ def test_send_one_off_email_with_file_via_ui(driver, login_seeded_user):
     # delete the template
     assert view_email_template_page.get_h1_text() == template_name
     delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
+
 
 @recordtime
 @pytest.mark.xdist_group(name="send-files-via-ui-flow")
@@ -292,6 +296,7 @@ def test_send_file_via_ui_preview_pages(driver, login_seeded_user, download_dire
     assert view_email_template_page.get_h1_text() == template_name
     delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
 
+
 @recordtime
 @pytest.mark.xdist_group(name="send-files-via-ui-flow")
 def test_send_email_notification_with_an_email_file_via_csv(driver, login_seeded_user):
@@ -336,13 +341,16 @@ def test_send_email_notification_with_an_email_file_via_csv(driver, login_seeded
     set_sender_page.click_continue_button()
 
     send_via_csv_page = SendViaCsvPage(driver)
+    assert send_via_csv_page.get_h1_text() == f"Send ‘{template_name}’"
     # create temp csv for this test
+    send_via_csv_page.go_to_upload_csv_for_service_and_template(config["service"]["id"], template_id)
+    upload_csv_page = SendFilesViaUiUploadCsvPage(driver)
+    assert send_via_csv_page.get_h1_text() == "Upload a list of email addresses"
     seeded_user_email = generate_unique_email(
         config["service"]["seeded_user"]["email"], "test_send_file_via_ui_preview_pages"
     )
     _, directory, csv_filename = create_temp_csv({"email address": seeded_user_email}, include_build_id=True)
-    send_via_csv_page.go_to_upload_csv_for_service_and_template(config["service"]["id"], template_id)
-    send_via_csv_page.upload_csv(directory, csv_filename)
+    upload_csv_page.upload_csv(directory, csv_filename)
     send_via_csv_preview_page = SendViaCsvPreviewPage(send_via_csv_page.driver)
     assert send_via_csv_preview_page.get_h1_text() == f"Preview of {template_name}"
     send_via_csv_preview_page.click_send()
@@ -358,16 +366,17 @@ def test_send_email_notification_with_an_email_file_via_csv(driver, login_seeded
 
     # Confirm that the file download link sent to the recipient works
     # There are smoke tests and other tests covering the process of a recipient downloading
-    # a document, so the whole journey will not be covered here
+    # a document, so the whole journey will not be covered here. we will just check that the link
+    # goes to the download page and that it is not the preview landing page
     send_email_confirmation_page.click_file_download_link(link_text)
-    you_have_a_file_to_download_page = DocumentDownloadLandingPage(driver)
-    assert you_have_a_file_to_download_page.get_h1_text() == "You have a file to download"
-    you_have_a_file_to_download_page.go_to_download_page()
+    document_download_landing_page = DocumentDownloadLandingPage(driver)
+    assert document_download_landing_page.get_h1_text() == "You have a file to download"
+    assert len(driver.find_elements(By.CLASS_NAME, "govuk-notification-banner")) == 0  # No banner present
 
     # Go to service templates page and select the template
     base_url = config["notify_admin_url"]
     service_template_page_url = f"{base_url}/services/{config['service']['id']}/templates"
-    you_have_a_file_to_download_page.get(service_template_page_url)
+    document_download_landing_page.get(service_template_page_url)
     templates_pages = ShowTemplatesPage(driver)
     assert templates_pages.get_h1_text() == "Templates"
     templates_pages.click_template_by_link_text(template_name)

--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -59,13 +59,7 @@ def test_attaching_files_to_emails_and_also_deleting_them_via_ui(driver, login_s
 
     # delete template
     assert view_email_template_page.get_h1_text() == template_name
-    view_email_template_page.click_delete_template_link()
-    view_email_template_page.click_template_deletion_confirmation_button()
-
-    # confirm template has been deleted
-    templates_page = ShowTemplatesPage(driver)
-    assert templates_page.get_h1_text() == "Templates"
-    assert template_name not in templates_page.get_all_listed_templates()
+    delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
 
 
 @recordtime
@@ -142,14 +136,7 @@ def test_send_one_off_email_with_file_via_ui(driver, login_seeded_user):
 
     # delete the template
     assert view_email_template_page.get_h1_text() == template_name
-    view_email_template_page.click_delete_template_link()
-    view_email_template_page.click_template_deletion_confirmation_button()
-
-    # confirm template has been deleted
-    templates_page = ShowTemplatesPage(driver)
-    assert templates_page.get_h1_text() == "Templates"
-    assert template_name not in templates_page.get_all_listed_templates()
-
+    delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
 
 @recordtime
 @pytest.mark.xdist_group(name="send-files-via-ui-flow")
@@ -224,13 +211,7 @@ def test_email_template_file_management_settings(driver, login_seeded_user):
     manage_a_file_page.click_back_link()
     manage_files_page.click_back_link()
     assert view_email_template_page.get_h1_text() == template_name
-    view_email_template_page.click_delete_template_link()
-    view_email_template_page.click_template_deletion_confirmation_button()
-
-    # confirm template has been deleted
-    templates_page = ShowTemplatesPage(driver)
-    assert templates_page.get_h1_text() == "Templates"
-    assert template_name not in templates_page.get_all_listed_templates()
+    delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
 
 
 @recordtime
@@ -309,13 +290,7 @@ def test_send_file_via_ui_preview_pages(driver, login_seeded_user, download_dire
     templates_page = ShowTemplatesPage(driver)
     templates_page.click_template_by_link_text(template_name)
     assert view_email_template_page.get_h1_text() == template_name
-    view_email_template_page.click_delete_template_link()
-    view_email_template_page.click_template_deletion_confirmation_button()
-
-    # confirm template has been deleted
-
-    assert templates_page.get_h1_text() == "Templates"
-    assert template_name not in templates_page.get_all_listed_templates()
+    delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
 
 @recordtime
 @pytest.mark.xdist_group(name="send-files-via-ui-flow")
@@ -399,6 +374,10 @@ def test_send_email_notification_with_an_email_file_via_csv(driver, login_seeded
 
     # delete the template
     assert view_email_template_page.get_h1_text() == template_name
+    delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name)
+
+
+def delete_email_template_for_send_file_via_ui_tests(driver, view_email_template_page, template_name):
     view_email_template_page.click_delete_template_link()
     view_email_template_page.click_template_deletion_confirmation_button()
 

--- a/tests/notifications/functional_tests/test_document_download_via_ui.py
+++ b/tests/notifications/functional_tests/test_document_download_via_ui.py
@@ -21,13 +21,14 @@ from tests.pages import (
     PreviewDownloadYourFilePage,
     PreviewYouHaveAFileToDownloadPage,
     ShowTemplatesPage,
-    ViewEmailTemplatePage,
+    ViewEmailTemplatePage, SendViaCsvPage, SendViaCsvPreviewPage, JobPage,
 )
+from tests.postman import send_notification_via_csv
 from tests.test_utils import (
     create_an_email_template_and_attach_a_file,
     delete_file_from_email_template_via_manage_files_page,
     get_downloaded_document,
-    recordtime,
+    recordtime, create_temp_csv,
 )
 
 
@@ -313,5 +314,95 @@ def test_send_file_via_ui_preview_pages(driver, login_seeded_user, download_dire
 
     # confirm template has been deleted
 
+    assert templates_page.get_h1_text() == "Templates"
+    assert template_name not in templates_page.get_all_listed_templates()
+
+@recordtime
+@pytest.mark.xdist_group(name="send-files-via-ui-flow")
+def test_send_email_notification_with_an_email_file_via_csv(driver, login_seeded_user):
+    # Create an email template
+    template_name = f"Functional Tests - send email with file via csv - {uuid.uuid4()}"
+    content = "Testing sending a one off email notification. with an email file. Test file below:"
+    file_name = "attachment.pdf"
+    template_id = create_an_email_template_and_attach_a_file(driver, file_name, template_name, content)
+
+    # Confirm file has been attached to template on the Preview email template page
+    view_email_template_page = ViewEmailTemplatePage(driver)
+    assert view_email_template_page.get_h1_text() == template_name
+    assert view_email_template_page.get_file_added_count_text() == "1 file added"
+
+    # go to the individual file management page and change the link text
+    view_email_template_page.click_manage_files_button()
+    manage_files_page = ManageFilesForEmailTemplatePage(driver)
+    assert manage_files_page.get_h1_text() == "Manage files"
+    link_text_label = "Link text"
+    link_text = "file_download_link"
+    manage_files_page.click_manage_link(file_name)
+    manage_file_page = ManageEmailTemplateFilePage(driver)
+    assert manage_file_page.get_h1_text() == file_name
+    manage_file_page.click_change_file_setting(link_text_label)
+    change_link_text_page = ChangeLinkTextForEmailFilePage(driver)
+    assert change_link_text_page.get_h1_text() == "Add link text"
+    change_link_text_page.fill_in_link_text(link_text)
+    change_link_text_page.click_continue_button()
+
+    manage_file_page.click_back_link()
+    assert manage_file_page.get_h1_text() == "Manage files"
+    manage_file_page.click_back_link()
+
+    # send the email
+    assert view_email_template_page.get_h1_text() == template_name
+    assert link_text in view_email_template_page.get_email_message_body_content()
+    view_email_template_page.click_send()
+
+    set_sender_page = SendSetSenderPage(driver)
+    set_sender_page.wait_until_current()
+    assert set_sender_page.get_h1_text() == "Where should replies come back to?"
+    set_sender_page.click_continue_button()
+
+    send_via_csv_page = SendViaCsvPage(driver)
+    # create temp csv for this test
+    seeded_user_email = generate_unique_email(
+        config["service"]["seeded_user"]["email"], "test_send_file_via_ui_preview_pages"
+    )
+    _, directory, csv_filename = create_temp_csv({"email address": seeded_user_email}, include_build_id=True)
+    send_via_csv_page.go_to_upload_csv_for_service_and_template(config["service"]["id"], template_id)
+    send_via_csv_page.upload_csv(directory, csv_filename)
+    send_via_csv_preview_page = SendViaCsvPreviewPage(send_via_csv_page.driver)
+    assert send_via_csv_preview_page.get_h1_text() == f"Preview of {template_name}"
+    send_via_csv_preview_page.click_send()
+    job_page = JobPage(driver)
+    assert job_page.get_h1_text() == f"{csv_filename}"
+    job_page.go_to_notification_page()
+
+    # confirm that the email is being delivered
+    send_email_confirmation_page = SentEmailMessagePage(driver)
+    assert send_email_confirmation_page.get_h1_text() == "Email"
+    status = send_email_confirmation_page.get_notification_status()
+    assert "Delivering" in status or "Delivered"  # Either status pops up, depending on the test run
+
+    # Confirm that the file download link sent to the recipient works
+    # There are smoke tests and other tests covering the process of a recipient downloading
+    # a document, so the whole journey will not be covered here
+    send_email_confirmation_page.click_file_download_link(link_text)
+    you_have_a_file_to_download_page = DocumentDownloadLandingPage(driver)
+    assert you_have_a_file_to_download_page.get_h1_text() == "You have a file to download"
+    you_have_a_file_to_download_page.go_to_download_page()
+
+    # Go to service templates page and select the template
+    base_url = config["notify_admin_url"]
+    service_template_page_url = f"{base_url}/services/{config['service']['id']}/templates"
+    you_have_a_file_to_download_page.get(service_template_page_url)
+    templates_pages = ShowTemplatesPage(driver)
+    assert templates_pages.get_h1_text() == "Templates"
+    templates_pages.click_template_by_link_text(template_name)
+
+    # delete the template
+    assert view_email_template_page.get_h1_text() == template_name
+    view_email_template_page.click_delete_template_link()
+    view_email_template_page.click_template_deletion_confirmation_button()
+
+    # confirm template has been deleted
+    templates_page = ShowTemplatesPage(driver)
     assert templates_page.get_h1_text() == "Templates"
     assert template_name not in templates_page.get_all_listed_templates()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -196,6 +196,16 @@ class BasePage:
             ),
         )
 
+    def wait_for_element_to_be_clickable(self, locator, time=10):
+        return AntiStaleElement(
+            self.driver,
+            locator,
+            lambda locator: WebDriverWait(self.driver, time).until(
+                EC.element_to_be_clickable(locator),
+                self.no_element_error_msg(locator),
+            ),
+        )
+
     def wait_until_element_is_not_present(self, locator, time=10):
         return WebDriverWait(self.driver, time).until(
             EC.invisibility_of_element_located(locator),
@@ -1216,6 +1226,7 @@ class SendViaCsvPreviewPage(PageWithCsvPreview, PageWithSendToMultipleButton):
 class JobPage(BasePage):
     uploads_link = (By.LINK_TEXT, "Uploads")
     first_notification = JobPageLocators.FIRST_NOTIFICATION
+    notification_link = (By.CLASS_NAME, "file-list-filename")
 
     def wait_until_current(self, time=10):
         return self.wait_until_url_contains("/jobs/", time=time)
@@ -1238,6 +1249,14 @@ class JobPage(BasePage):
     def click_uploads(self):
         element = self.wait_for_element(self.uploads_link)
         element.click()
+
+    @retry(RetryException, tries=20, delay=10)
+    def go_to_notification_page(self):
+        try:
+            element = self.wait_for_element_to_be_clickable(self.notification_link)
+            element.click()
+        except TimeoutException as e:
+            raise RetryException("Could not find element...") from e
 
 
 class PageWithUploadsList(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -921,6 +921,7 @@ class ViewEmailTemplatePage(ViewTemplatePage):
     def get_email_message_body_content(self):
         element = self.wait_for_element(ViewEmailTemplatePage.email_message_body_content)
         return element.text.strip()
+
     def click_file_link_text(self, link_text):
         element = self.wait_for_element((By.XPATH, f"//a[contains(text(), '{link_text}')]"))
         element.click()
@@ -1180,6 +1181,30 @@ class SendViaCsvPage(PageWithCsvUpload):
     def go_to_upload_csv_for_service_and_template(self, service_id, template_id):
         url = f"{self.base_url}/services/{service_id}/send/{template_id}/csv"
         self.driver.get(url)
+
+
+class SendFilesViaUiUploadCsvPage(SendViaCsvPage):
+    """
+    This class overrides the csv upload methods of the
+    SendViaCsvPage class to be a better fit for the send file via ui flow.
+    The SendViaCsvPage class covers both the "send template" page and the
+    "upload csv pages". This splits out csv upload page.
+    work wil be done to reconcile the differences with the other csv upload test flows
+    """
+
+    file_input = (By.ID, "hidden-file")
+
+    def upload_csv(self, directory, path):
+        file_path = os.path.join(directory, path)
+        element = self.wait_for_presence_of_element(self.file_input)
+        # Fill in the hidden file input bypassing the OS file management dialog
+        element[0].send_keys(file_path)
+        self.wait_until_not_current()
+        shutil.rmtree(directory, ignore_errors=True)
+
+    def wait_until_not_current(self, time=13):
+        # slightly increasing the time here so that the browser has more time to read the file before it is removed
+        return self.wait_until_url_doesnt_match(self.url_re, time=time)
 
 
 class PageWithCsvPreview(BasePage):

--- a/tests/postman.py
+++ b/tests/postman.py
@@ -26,7 +26,7 @@ def send_precompiled_letter_via_api(reference, client, pdf_file):
     return resp_json["id"]
 
 
-def send_notification_via_csv(send_via_csv_page, message_type: str, seeded: bool = False):
+def send_notification_via_csv(send_via_csv_page, message_type: str, seeded: bool = False, template_id=None):
     template_id = config["service"]["templates"][message_type]
     _, directory, filename = get_temp_csv_for_message_type(message_type, seeded=seeded, include_build_id=True)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,7 +62,7 @@ class NotificationStatuses:
     SENT = RECEIVED | DELIVERED | {"sending", "pending"}
 
 
-def create_temp_csv(fields: dict[str, Any], include_build_id: bool = True) -> tuple[str, str]:
+def create_temp_csv(fields: dict[str, Any], include_build_id: bool = True) -> tuple[list, str, str]:
     directory_name = tempfile.mkdtemp()
     csv_filename = f"{uuid.uuid4()}-sample.csv"
     csv_file_path = os.path.join(directory_name, csv_filename)
@@ -649,7 +649,7 @@ def pdf_page_has_text(pdf_page, expected_text, normalise_whitespace=True):
 
 def create_an_email_template_and_attach_a_file(driver, file_name, template_name, content):
     go_to_templates_page(driver)
-    create_email_template(driver, name=template_name, content=content, has_unsubscribe_link=True)
+    template_id = create_email_template(driver, name=template_name, content=content, has_unsubscribe_link=True)
 
     # Upload file and add it to the template
     dashboard_page = DashboardPage(driver)
@@ -657,6 +657,7 @@ def create_an_email_template_and_attach_a_file(driver, file_name, template_name,
     dashboard_page.go_to_dashboard_for_service(service_id=service_id)
     file_path = f"tests/test_files/{file_name}"
     add_file_to_email_template(driver, template_name, file_name, file_path, service_id)
+    return template_id
 
 
 def add_file_to_email_template(driver, template_name, file_name, file_path, service_id):


### PR DESCRIPTION
We had to revert the previously deployed Functional Tests for sending email notifications with files attached via `csv`, because they were unexpectedly flaky.

In  this PR, the test does not use the existing `send_notification_via_csv` used by other FTs. The plan is to refactor the code in subsequent PRs and address the slight nuances that meant the existing code used in by other tests hasn't worked in the send file vi ui tests.

Also subsequent PRs will refactor all the send file via ui FTs to keep things DRY. The priority is to get the test working so that the feature can be deployed.

I have added comments to try to describe the reasoning for not using some of the existing code and patterns used in other FTs (ie not send file via ui)