### PR TITLE
`client_live_key`, `client_test_key` fixtures: provide `client_id` for correlation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from notifications_python_client import NotificationsAPIClient
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.support.events import EventFiringWebDriver
@@ -12,6 +11,7 @@ from config import config, setup_shared_config
 from tests.event_listener import LoggingEventListener
 from tests.pages.pages import HomePage
 from tests.pages.rollups import sign_in, sign_in_email_auth
+from tests.test_utils import FTNotificationsAPIClient
 
 
 def pytest_addoption(parser):
@@ -124,12 +124,28 @@ def login_seeded_user(_driver, request: pytest.FixtureRequest):
 
 
 @pytest.fixture(scope="module")
-def client_live_key():
-    client = NotificationsAPIClient(base_url=config["notify_api_url"], api_key=config["service"]["api_live_key"])
+def _client_live_key():
+    client = FTNotificationsAPIClient(base_url=config["notify_api_url"], api_key=config["service"]["api_live_key"])
     return client
 
 
 @pytest.fixture(scope="module")
-def client_test_key():
-    client = NotificationsAPIClient(base_url=config["notify_api_url"], api_key=config["service"]["api_test_key"])
+def _client_test_key():
+    client = FTNotificationsAPIClient(base_url=config["notify_api_url"], api_key=config["service"]["api_test_key"])
     return client
+
+
+@pytest.fixture(scope="function")
+def client_live_key(_client_live_key, request):
+    prev_failed_tests = request.session.testsfailed
+    yield _client_live_key
+    if prev_failed_tests != request.session.testsfailed:
+        print("client_live_key client id:", str(getattr(_client_live_key, "_client_id", None)))  # noqa: T201
+
+
+@pytest.fixture(scope="function")
+def client_test_key(_client_test_key, request):
+    prev_failed_tests = request.session.testsfailed
+    yield _client_test_key
+    if prev_failed_tests != request.session.testsfailed:
+        print("client_test_key client id:", str(getattr(_client_test_key, "_client_id", None)))  # noqa: T201

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,6 +59,19 @@ class NotificationStatuses:
     SENT = RECEIVED | DELIVERED | {"sending", "pending"}
 
 
+class FTNotificationsAPIClient(NotificationsAPIClient):
+    _client_id: uuid.UUID
+
+    def __init__(self, *args, **kwargs):
+        self._client_id = uuid.uuid4()
+        super().__init__(*args, **kwargs)
+
+    def generate_headers(self, api_token):
+        r = super().generate_headers(api_token)
+        r["User-agent"] = f"{r["User-agent"]}/client-{self._client_id}"
+        return r
+
+
 def create_temp_csv(fields: dict[str, Any], include_build_id: bool = True) -> tuple[list, str, str]:
     directory_name = tempfile.mkdtemp()
     csv_filename = f"{uuid.uuid4()}-sample.csv"
@@ -540,7 +553,7 @@ def _assert_one_off_email_filled_in_properly(driver, template_name, test, recipi
 
 
 def get_notification_by_to_field(template_id, api_key, sent_to, statuses=None):
-    client = NotificationsAPIClient(base_url=config["notify_api_url"], api_key=api_key)
+    client = FTNotificationsAPIClient(base_url=config["notify_api_url"], api_key=api_key)
     resp = client.get("v2/notifications")
     for notification in resp["notifications"]:
         t_id = notification["template"]["id"]


### PR DESCRIPTION
Functioning similarly to `driver_id` and included in `User-agent`, this should make it possible to correlate requests from a particular FT process with its corresponding logs server-side.