### PR TITLE
Change sticky JS to use a plain DOM node as arg

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -310,7 +310,7 @@ class PageWithStickyNavMixin:
 
         if selector is not None:
             js_str = (
-                f"if ('scrollToRevealElement' in {namespace}){namespace}.scrollToRevealElement($('{selector}').eq(0))"
+                f"if ('scrollToRevealElement' in {namespace}){namespace}.scrollToRevealElement(document.querySelector('{selector}'))"
             )
             self.driver.execute_script(js_str)
         elif xpath is not None:
@@ -318,7 +318,7 @@ class PageWithStickyNavMixin:
                              if ('scrollToRevealElement' in {namespace}) {{
                                  var matches = document.evaluate("{xpath}", document, null, XPathResult.ANY_TYPE, null);
                                  if (matches) {{
-                                     {namespace}.scrollToRevealElement($(matches.iterateNext()));
+                                     {namespace}.scrollToRevealElement(matches.iterateNext());
                                  }}
                              }}
                          }}(document));"""


### PR DESCRIPTION
We've changed these methods to take a DOM node, as part of removing jQuery from the codebase.

See this pull request:

https://github.com/alphagov/notifications-admin/pull/5924