### PR TITLE
fix: flaky waits after attaching a file and deleting a template

### DIFF
--- a/tests/notifications/functional_tests/test_send_files_via_ui.py
+++ b/tests/notifications/functional_tests/test_send_files_via_ui.py
@@ -375,6 +375,7 @@ def add_file_to_email_template(driver, file_name, template_name):
     manage_a_file_page = ManageEmailTemplateFilePage(driver)
     assert manage_a_file_page.get_h1_text() == file_name
     manage_a_file_page.click_add_to_template()
+    manage_a_file_page.wait_until_url_doesnt_contain("/files/")
     # Confirm file has been attached to template on the Preview email template page
     assert_file_has_been_attached_to_email_template(driver, template_name)
 

--- a/tests/notifications/functional_tests/test_send_files_via_ui.py
+++ b/tests/notifications/functional_tests/test_send_files_via_ui.py
@@ -290,6 +290,7 @@ def delete_template_from_view_email_template_page(driver, template_name):
     view_email_template_page = ViewEmailTemplatePage(driver)
     view_email_template_page.click_delete_template_link()
     view_email_template_page.click_template_deletion_confirmation_button()
+    view_email_template_page.wait_until_url_doesnt_contain("/delete")
 
     # confirm template has been deleted
     templates_page = ShowTemplatesPage(driver)


### PR DESCRIPTION
I found these flaky tests from these failed runs today in staging:

https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1943
https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1943.1

**Add file to template flow**

1. Template preview: /services/S/templates/T
2. Upload file: /services/S/templates/T/files/upload
3. Manage that file: /services/S/templates/T/files/F
4. Click Add to template → redirects back to /services/S/templates/T

Without the wait, the test sometimes checked the heading while still on step 3 (.../files/F).

**Delete template flow**

1. Template preview: /services/S/templates/T
2. Confirm delete: /services/S/templates/T/delete (heading = template name)
3. Click Yes, delete → redirects to /services/S/templates (heading = “Templates”)

Without the wait, the test sometimes checked for “Templates” while still on step 2.