### PR TITLE
fix: flakey test test_template_folder_permissions

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1413,6 +1413,11 @@ class InviteUserPage(BasePage):
     def send_invitation(self):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()
+        # Wait for redirect to team members list after saving permissions or sending an invite.
+        # Without this, navigating away too quickly can abort the in-flight form POST.
+        # Note: if the form fails validation the page re-renders instead of redirecting,
+        # so this raises TimeoutException, which is the failure we'd want to see.
+        self.wait_until_url_matches(r"/services/[^/]+/users/?$")
 
     # support variants of this page with a 'Save' button instead of 'Send invitation' (both use the same locator)
     def click_save(self):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1410,18 +1410,18 @@ class InviteUserPage(BasePage):
             element = self.wait_for_design_system_checkbox_or_radio(InviteUserPage.manage_api_keys_checkbox)
             self.select_checkbox_or_radio(element)
 
-    def send_invitation(self):
+    def _submit_and_wait_for_team_members(self):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()
-        # Wait for redirect to team members list after saving permissions or sending an invite.
-        # Without this, navigating away too quickly can abort the in-flight form POST.
-        # Note: if the form fails validation the page re-renders instead of redirecting,
-        # so this raises TimeoutException, which is the failure we'd want to see.
+        # If validation fails, the page does not redirect and this raises TimeoutException.
         self.wait_until_url_matches(r"/services/[^/]+/users/?$")
+
+    def send_invitation(self):
+        self._submit_and_wait_for_team_members()
 
     # support variants of this page with a 'Save' button instead of 'Send invitation' (both use the same locator)
     def click_save(self):
-        self.send_invitation()
+        self._submit_and_wait_for_team_members()
 
     def uncheck_folder_permission_checkbox(self, folder_name):
         try:


### PR DESCRIPTION
### Summary

fix test_template_folder_permissions which I saw failing here: https://concourse.notify.tools/teams/staging/pipelines/deploy-notify/jobs/functional-tests/builds/1952

Team members: /services/S/users
- Edit team member: /services/S/users/U (uncheck a folder permission checkbox)
- Click Save → form POST → redirects back to /services/S/users

Without the wait, the test clicked the "Team members" nav link immediately after clicking Save. 
It went away while the save POST was still running made the browser cancel the POST, so the permission change was never saved. The test then reopened the edit page and found the checkbox still checked, failing with AssertionError: assert not 'true'.

By adding the wait we make sure the redirect is there before moving on

Since `click_save()`  and  `send_invitation()`, make use of the same pattern, so this also protects the invitation flow 

Thing to mention is that if the form  fails validation, the page re-renders at the same URL instead of redirecting, so the wait raises a TimeoutException (after 10 seconds I think). 

I think that's the correct way to fail vbecause if something really is wrong with the submit, I'd rather the test blow up at the submit with a TimeoutException than mask it and surface a confusing assertion error downstream like is happening now. 

